### PR TITLE
Fix return when returning tuple

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -52,6 +52,18 @@ fn takes_slice(slice: &str) {
     println!("Got: {}", slice);
 }
 
+fn foo() -> [u32; 2] {
+    return [1, 2];
+}
+
+fn foo() -> (u32, u16) {
+    return (1, 2);
+}
+
+fn foo() {
+    return
+}
+
 ---
 
 (source_file
@@ -66,7 +78,13 @@ fn takes_slice(slice: &str) {
   (function_item (identifier)
     (parameters
       (parameter (identifier) (reference_type (primitive_type))))
-    (block (macro_invocation (identifier) (token_tree (string_literal) (identifier))))))
+    (block (macro_invocation (identifier) (token_tree (string_literal) (identifier)))))
+  (function_item (identifier) (parameters) (array_type (primitive_type) (integer_literal))
+    (block (return_expression (array_expression (integer_literal) (integer_literal)))))
+  (function_item (identifier) (parameters) (tuple_type (primitive_type) (primitive_type))
+    (block (return_expression (tuple_expression (integer_literal) (integer_literal)))))
+  (function_item (identifier) (parameters)
+    (block (return_expression))))
 
 ============================================
 Const function declarations

--- a/grammar.js
+++ b/grammar.js
@@ -968,8 +968,9 @@ module.exports = grammar({
       $._expression, 'as', $._type
     ),
 
-    return_expression: $ => prec.left(seq(
-      'return', optional($._expression))
+    return_expression: $ => choice(
+      prec.left(0, seq('return', $._expression)),
+      prec(-1, 'return'),
     ),
 
     call_expression: $ => prec(PREC.call, seq(

--- a/grammar.js
+++ b/grammar.js
@@ -969,7 +969,7 @@ module.exports = grammar({
     ),
 
     return_expression: $ => choice(
-      prec.left(0, seq('return', $._expression)),
+      prec.left(seq('return', $._expression)),
       prec(-1, 'return'),
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5137,29 +5137,34 @@
       ]
     },
     "return_expression": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "return"
-          },
-          {
-            "type": "CHOICE",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
             "members": [
+              {
+                "type": "STRING",
+                "value": "return"
+              },
               {
                 "type": "SYMBOL",
                 "name": "_expression"
-              },
-              {
-                "type": "BLANK"
               }
             ]
           }
-        ]
-      }
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "STRING",
+            "value": "return"
+          }
+        }
+      ]
     },
     "call_expression": {
       "type": "PREC",


### PR DESCRIPTION
Returning a tuple was considered as a call_expression (with fn "return") and returning an array was considered as taking a slice. 