### PR TITLE
Generalize attribute syntax

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -176,13 +176,13 @@ fn accumulate(self) -> Machine<{State::Accumulate}> {}
     name: (identifier)
     parameters: (parameters
       (attribute_item
-        (meta_item
+        (attr_item
           (identifier)))
       (parameter
         pattern: (identifier)
         type: (primitive_type))
       (attribute_item
-        (meta_item
+        (attr_item
           (identifier)))
       (parameter
         pattern: (identifier)
@@ -473,7 +473,7 @@ struct Inches(i32);
         (field_identifier)
         (primitive_type))
       (attribute_item
-        (meta_item
+        (attr_item
           (identifier)))
       (field_declaration
         (field_identifier)
@@ -632,10 +632,10 @@ pub enum Node<T: Item> {
             (field_identifier)
             (primitive_type))))
       (attribute_item
-        (meta_item
+        (attr_item
           (identifier)))
       (attribute_item
-        (meta_item
+        (attr_item
           (identifier)))
       (enum_variant
         (identifier)
@@ -968,7 +968,7 @@ mod macos_only {}
             path: (identifier)
             name: (identifier))))))
   (attribute_item
-    (meta_item
+    (attr_item
       (scoped_identifier
         path: (identifier)
         name: (identifier))
@@ -1119,7 +1119,7 @@ fn foo() {
         pattern: (identifier)
         value: (array_expression
           (attribute_item
-            (meta_item
+            (attr_item
               (identifier)))
           (integer_literal)
           (integer_literal)
@@ -1128,7 +1128,7 @@ fn foo() {
         pattern: (identifier)
         value: (tuple_expression
           (attribute_item
-            (meta_item
+            (attr_item
               (identifier)))
           (integer_literal)
           (integer_literal)

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -1048,7 +1048,7 @@ foo(#[bar(some tokens are special in other contexts: $/';()*()+.)] x);
       arguments: (arguments
         (attribute_item (attr_item
           (identifier)
-          arguments: (delim_token_tree (identifier) (identifier))))
+          arguments: (token_tree (identifier) (identifier))))
         (identifier)
         (identifier))))
   (expression_statement
@@ -1057,7 +1057,7 @@ foo(#[bar(some tokens are special in other contexts: $/';()*()+.)] x);
       arguments: (arguments
         (attribute_item (attr_item
           (identifier)
-          arguments: (delim_token_tree
+          arguments: (token_tree
             (identifier)
             (identifier)
             (identifier)
@@ -1065,8 +1065,8 @@ foo(#[bar(some tokens are special in other contexts: $/';()*()+.)] x);
             (identifier)
             (identifier)
             (identifier)
-            (delim_token_tree)
-            (delim_token_tree))))
+            (token_tree)
+            (token_tree))))
         (identifier)))))
 
 ================================================================================
@@ -1102,15 +1102,15 @@ pub enum Error {
     (enum_variant_list
       (attribute_item (attr_item
         (identifier)
-        (delim_token_tree
+        (token_tree
           (string_literal)
           (identifier)
-          (delim_token_tree (integer_literal)))))
+          (token_tree (integer_literal)))))
       (enum_variant (identifier)
         (ordered_field_declaration_list (type_identifier)))
       (attribute_item (attr_item
         (identifier)
-        (delim_token_tree
+        (token_tree
           (string_literal)
           (identifier)
           (identifier)

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -1038,6 +1038,8 @@ foo(#[bar(some tokens are special in other contexts: $/';()*()+.)] x);
 Derive macro helper attributes
 ================================================================================
 
+// Example from https://github.com/dtolnay/thiserror/blob/21c26903e29cb92ba1a7ff11e82ae2001646b60d/README.md
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -1051,6 +1053,7 @@ pub enum Error {
 --------------------------------------------------------------------------------
 
 (source_file
+  (line_comment)
   (use_declaration
     (scoped_identifier (identifier) (identifier)))
   (attribute_item

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -997,6 +997,93 @@ mod macos_only {
               value: (string_literal))))))))
 
 ================================================================================
+Attribute macros
+================================================================================
+
+foo(#[attr(=> arbitrary tokens <=)] x, y);
+
+foo(#[bar(some tokens are special in other contexts: $/';()*()+.)] x);
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (call_expression
+      function: (identifier)
+      arguments: (arguments
+        (attribute_item (attr_item
+          (identifier)
+          arguments: (delim_token_tree (identifier) (identifier))))
+        (identifier)
+        (identifier))))
+  (expression_statement
+    (call_expression
+      function: (identifier)
+      arguments: (arguments
+        (attribute_item (attr_item
+          (identifier)
+          arguments: (delim_token_tree
+            (identifier)
+            (identifier)
+            (identifier)
+            (identifier)
+            (identifier)
+            (identifier)
+            (identifier)
+            (delim_token_tree)
+            (delim_token_tree))))
+        (identifier)))))
+
+================================================================================
+Derive macro helper attributes
+================================================================================
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("first letter must be lowercase but was {:?}", first_char(.0))]
+    WrongCase(String),
+    #[error("invalid index {idx}, expected at least {} and at most {}", .limits.lo, .limits.hi)]
+    OutOfBounds { idx: usize, limits: Limits },
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (use_declaration
+    (scoped_identifier (identifier) (identifier)))
+  (attribute_item
+    (meta_item (identifier)
+      (meta_arguments
+        (meta_item (identifier))
+        (meta_item (identifier)))))
+  (enum_item
+    (visibility_modifier)
+    (type_identifier)
+    (enum_variant_list
+      (attribute_item (attr_item
+        (identifier)
+        (delim_token_tree
+          (string_literal)
+          (identifier)
+          (delim_token_tree (integer_literal)))))
+      (enum_variant (identifier)
+        (ordered_field_declaration_list (type_identifier)))
+      (attribute_item (attr_item
+        (identifier)
+        (delim_token_tree
+          (string_literal)
+          (identifier)
+          (identifier)
+          (identifier)
+          (identifier))))
+      (enum_variant (identifier)
+        (field_declaration_list
+          (field_declaration (field_identifier) (primitive_type))
+          (field_declaration (field_identifier) (type_identifier)))))))
+
+================================================================================
 Attributes and Expressions
 ================================================================================
 

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -997,6 +997,41 @@ mod macos_only {
               value: (string_literal))))))))
 
 ================================================================================
+Key-Value Attribute Expressions
+================================================================================
+
+#[doc = include_str!("foo-doc.md")]
+fn foo() {}
+
+#[namespace = foo::bar]
+fn baz() {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (attribute_item
+    (meta_item
+      (identifier)
+      (macro_invocation
+        (identifier)
+        (token_tree
+          (string_literal)))))
+  (function_item
+    (identifier)
+    (parameters)
+    (block))
+  (attribute_item
+    (attr_item
+      (identifier)
+      (scoped_identifier
+        (identifier)
+        (identifier))))
+  (function_item
+    (identifier)
+    (parameters)
+    (block)))
+
+================================================================================
 Attribute macros
 ================================================================================
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -607,7 +607,7 @@ let msg = match x {
           value: (integer_literal))
         (match_arm
           (attribute_item
-            (meta_item
+            (attr_item
               (identifier)))
           pattern: (match_pattern
             (integer_literal))

--- a/grammar.js
+++ b/grammar.js
@@ -278,7 +278,7 @@ module.exports = grammar({
     custom_attr: $ => seq(
       $._path,
       optional(choice(
-        seq('=', field('value', $._literal)),
+        seq('=', field('value', $._expression)),
         field('arguments', $.delim_token_tree)
       ))
     ),
@@ -286,7 +286,7 @@ module.exports = grammar({
     built_in_attr: $ => seq(
       $._built_in_attr_path,
       optional(choice(
-        seq('=', field('value', $._literal)),
+        seq('=', field('value', $._expression)),
         field('arguments', $.meta_arguments)
       ))
     ),
@@ -298,7 +298,7 @@ module.exports = grammar({
     meta_item: $ => seq(
       $._path,
       optional(choice(
-        seq('=', field('value', $._literal)),
+        seq('=', field('value', $._expression)),
         field('arguments', $.meta_arguments)
       ))
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -35,6 +35,54 @@ const numeric_types = [
 
 const primitive_types = numeric_types.concat(['bool', 'str', 'char'])
 
+const built_in_attributes = [
+  'cfg',
+  'cfg_attr',
+  'test',
+  'ignore',
+  'should_panic',
+  'derive',
+  'automatically_derived',
+  'macro_export',
+  'macro_use',
+  'proc_macro',
+  'proc_macro_derive',
+  'proc_macro_attribute',
+  'allow',
+  'warn',
+  'deny',
+  'forbid',
+  'deprecated',
+  'must_use',
+  'link',
+  'link_name',
+  'no_link',
+  'repr',
+  'crate_type',
+  'no_main',
+  'export_name',
+  'link_section',
+  'no_mangle',
+  'used',
+  'crate_name',
+  'inline',
+  'cold',
+  'no_builtins',
+  'target_feature',
+  'track_caller',
+  'doc',
+  'no_std',
+  'no_implicit_prelude',
+  'path',
+  'recursion_limit',
+  'type_length_limit',
+  'panic_handler',
+  'global_allocator',
+  'windows_subsystem',
+  'feature',
+  'non_exhaustive'
+]
+
 module.exports = grammar({
   name: 'rust',
 
@@ -210,7 +258,7 @@ module.exports = grammar({
     attribute_item: $ => seq(
       '#',
       '[',
-      $.meta_item,
+      $._attr,
       ']'
     ),
 
@@ -218,8 +266,33 @@ module.exports = grammar({
       '#',
       '!',
       '[',
-      $.meta_item,
+      $._attr,
       ']'
+    ),
+
+    _attr: $ => choice(
+      alias($.built_in_attr, $.meta_item),
+      alias($.custom_attr, $.attr_item),
+    ),
+
+    custom_attr: $ => seq(
+      $._path,
+      optional(choice(
+        seq('=', field('value', $._literal)),
+        field('arguments', $.delim_token_tree)
+      ))
+    ),
+
+    built_in_attr: $ => seq(
+      $._built_in_attr_path,
+      optional(choice(
+        seq('=', field('value', $._literal)),
+        field('arguments', $.meta_arguments)
+      ))
+    ),
+
+    _built_in_attr_path: $ => choice(
+      ...built_in_attributes.map(name => alias(name, $.identifier))
     ),
 
     meta_item: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -279,7 +279,7 @@ module.exports = grammar({
       $._path,
       optional(choice(
         seq('=', field('value', $._expression)),
-        field('arguments', $.delim_token_tree)
+        field('arguments', alias($.delim_token_tree, $.token_tree))
       ))
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -897,7 +897,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "meta_item"
+          "name": "_attr"
         },
         {
           "type": "STRING",
@@ -922,11 +922,538 @@
         },
         {
           "type": "SYMBOL",
-          "name": "meta_item"
+          "name": "_attr"
         },
         {
           "type": "STRING",
           "value": "]"
+        }
+      ]
+    },
+    "_attr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "built_in_attr"
+          },
+          "named": true,
+          "value": "meta_item"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "custom_attr"
+          },
+          "named": true,
+          "value": "attr_item"
+        }
+      ]
+    },
+    "custom_attr": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_path"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "="
+                    },
+                    {
+                      "type": "FIELD",
+                      "name": "value",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "FIELD",
+                  "name": "arguments",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "delim_token_tree"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "built_in_attr": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_built_in_attr_path"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "="
+                    },
+                    {
+                      "type": "FIELD",
+                      "name": "value",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "FIELD",
+                  "name": "arguments",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "meta_arguments"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_built_in_attr_path": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "cfg"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "cfg_attr"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "test"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "ignore"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "should_panic"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "derive"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "automatically_derived"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "macro_export"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "macro_use"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "proc_macro"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "proc_macro_derive"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "proc_macro_attribute"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "allow"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "warn"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "deny"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "forbid"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "deprecated"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "must_use"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "link"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "link_name"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "no_link"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "repr"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "crate_type"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "no_main"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "export_name"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "link_section"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "no_mangle"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "used"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "crate_name"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "inline"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "cold"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "no_builtins"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "target_feature"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "track_caller"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "doc"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "no_std"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "no_implicit_prelude"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "path"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "recursion_limit"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "type_length_limit"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "panic_handler"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "global_allocator"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "windows_subsystem"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "feature"
+          },
+          "named": true,
+          "value": "identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "non_exhaustive"
+          },
+          "named": true,
+          "value": "identifier"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -978,7 +978,7 @@
                       "name": "value",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "_literal"
+                        "name": "_expression"
                       }
                     }
                   ]
@@ -1025,7 +1025,7 @@
                       "name": "value",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "_literal"
+                        "name": "_expression"
                       }
                     }
                   ]
@@ -1482,7 +1482,7 @@
                       "name": "value",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "_literal"
+                        "name": "_expression"
                       }
                     }
                   ]

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -987,8 +987,13 @@
                   "type": "FIELD",
                   "name": "arguments",
                   "content": {
-                    "type": "SYMBOL",
-                    "name": "delim_token_tree"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "delim_token_tree"
+                    },
+                    "named": true,
+                    "value": "token_tree"
                   }
                 }
               ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -640,6 +640,62 @@
     }
   },
   {
+    "type": "attr_item",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "delim_token_tree",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_literal",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "crate",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "metavariable",
+          "named": true
+        },
+        {
+          "type": "scoped_identifier",
+          "named": true
+        },
+        {
+          "type": "self",
+          "named": true
+        },
+        {
+          "type": "super",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "attribute_item",
     "named": true,
     "fields": {},
@@ -647,6 +703,10 @@
       "multiple": false,
       "required": true,
       "types": [
+        {
+          "type": "attr_item",
+          "named": true
+        },
         {
           "type": "meta_item",
           "named": true
@@ -1336,6 +1396,49 @@
       "types": [
         {
           "type": "_declaration_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "delim_token_tree",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_literal",
+          "named": true
+        },
+        {
+          "type": "crate",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "mutable_specifier",
+          "named": true
+        },
+        {
+          "type": "primitive_type",
+          "named": true
+        },
+        {
+          "type": "self",
+          "named": true
+        },
+        {
+          "type": "super",
+          "named": true
+        },
+        {
+          "type": "token_tree",
           "named": true
         }
       ]
@@ -2379,6 +2482,10 @@
       "multiple": false,
       "required": true,
       "types": [
+        {
+          "type": "attr_item",
+          "named": true
+        },
         {
           "type": "meta_item",
           "named": true

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -658,7 +658,7 @@
         "required": false,
         "types": [
           {
-            "type": "_literal",
+            "type": "_expression",
             "named": true
           }
         ]
@@ -2822,7 +2822,7 @@
         "required": false,
         "types": [
           {
-            "type": "_literal",
+            "type": "_expression",
             "named": true
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -648,7 +648,7 @@
         "required": false,
         "types": [
           {
-            "type": "delim_token_tree",
+            "type": "token_tree",
             "named": true
           }
         ]
@@ -1396,49 +1396,6 @@
       "types": [
         {
           "type": "_declaration_statement",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "delim_token_tree",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "_literal",
-          "named": true
-        },
-        {
-          "type": "crate",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "mutable_specifier",
-          "named": true
-        },
-        {
-          "type": "primitive_type",
-          "named": true
-        },
-        {
-          "type": "self",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        },
-        {
-          "type": "token_tree",
           "named": true
         }
       ]


### PR DESCRIPTION
I attempted to fix #92. I didn't find a perfect solution; here's the resulting code, in case maintainers are interested.

I considered several approaches:
1. Parse attributes as [`meta-items`](https://doc.rust-lang.org/reference/attributes.html#meta-item-attribute-syntax) iff they match the `meta-item` syntax, and as general [`attrs`](https://doc.rust-lang.org/reference/attributes.html#attributes) otherwise. This preserves backwards compatibility, but creates a highly ambiguous grammar, since any `meta-item` is also a valid `attr`. I played around with `prec()`, `conflicts`, and `prec.dynamic()` but wasn't able to resolve the ambiguity correctly. Someone more familiar with LR/GLR parsing might be able to? In-progress code at https://github.com/ninevra/tree-sitter-rust/tree/ambiguitiy-and-precedence.
2. Parse [built-in attributes](https://doc.rust-lang.org/reference/attributes.html#built-in-attributes-index) as `meta-items`, and all others as `attrs`. This breaks backwards compatibility in that some custom attributes previously successfully parsed as `meta-items` and will now parse as `attrs`. It's arguably more correct than (1), since only built-in attributes are actually restricted to the `meta-item` syntax (see https://github.com/rust-lang/rust/pull/57367, https://github.com/rust-lang/rust/issues/57571). This is the approach taken in this PR.
3. Stop using the `meta-item` grammar at all and just use `attr`. This is fairly trivial, and I'd be happy to implement it if anyone wants. Breaks backwards compatibility for all attributes.

Are any of these options worth pursuing further?