### PR TITLE
0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-rust"
 description = "Rust grammar for the tree-sitter parsing library"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
 license = "MIT"
 readme = "bindings/rust/README.md"
@@ -23,7 +23,7 @@ autoexamples = false
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-rust",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Rust grammar for tree-sitter",
   "main": "bindings/node",
   "keywords": [
@@ -17,7 +17,7 @@
     "nan": "^2.14.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.1"
+    "tree-sitter-cli": "^0.20.0"
   },
   "scripts": {
     "test": "tree-sitter test && script/parse-examples",


### PR DESCRIPTION
This PR updates `tree-sitter-rust` to 0.20

@maxbrunsfeld 

Can we release it on crates.io also? Thanks in advance! :)