### PR TITLE
Add `tags.scm`

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,60 @@
+; ADT definitions
+
+(struct_item
+    name: (type_identifier) @name) @definition.class
+
+(enum_item
+    name: (type_identifier) @name) @definition.class
+
+(union_item
+    name: (type_identifier) @name) @definition.class
+
+; type aliases
+
+(type_item
+    name: (type_identifier) @name) @definition.class
+
+; method definitions
+
+(declaration_list
+    (function_item
+        name: (identifier) @name)) @definition.method
+
+; function definitions
+
+(function_item
+    name: (identifier) @name) @definition.function
+
+; trait definitions
+(trait_item
+    name: (type_identifier) @name) @definition.interface
+
+; module definitions
+(mod_item
+    name: (identifier) @name) @definition.module
+
+; macro definitions
+
+(macro_definition
+    name: (identifier) @name) @definition.macro
+
+; references
+
+(call_expression
+    function: (identifier) @name) @reference.call
+
+(call_expression
+    function: (field_expression
+        field: (field_identifier) @name)) @reference.call
+
+(macro_invocation
+    macro: (identifier) @name) @reference.call
+
+; implementations
+
+(impl_item
+    trait: (type_identifier) @name) @reference.implementation
+
+(impl_item
+    type: (type_identifier) @name
+    !trait) @reference.implementation


### PR DESCRIPTION
Thanks for all the effort on tree-sitter! Excited to see a lot of features are implemented on syntax trees this parser outputs.

This PR has high hopes to help the realization of Code Navigation feature for Rust. The output of `tree-sitter tags examples/ast.rs | head -n 30` is as follows:
```text
Lifetime         | class        def (36, 11) - (36, 19) `pub struct Lifetime {`
fmt              | method       def (43, 7) - (43, 10) `fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {`
write            | call         ref (44, 8) - (44, 13) `write!(f, "lifetime({}: {})", self.id, pprust::lifetime_to_string(self))`
LifetimeDef      | class        def (50, 11) - (50, 22) `pub struct LifetimeDef {`
Path             | class        def (63, 11) - (63, 15) `pub struct Path {`
eq               | method       def (71, 7) - (71, 9) `fn eq(&self, string: &&'a str) -> bool {`
len              | call         ref (72, 22) - (72, 25) `self.segments.len() == 1 && self.segments[0].identifier.name == *string`
fmt              | method       def (77, 7) - (77, 10) `fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {`
write            | call         ref (78, 8) - (78, 13) `write!(f, "path({})", pprust::path_to_string(self))`
fmt              | method       def (83, 7) - (83, 10) `fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {`
write            | call         ref (84, 8) - (84, 13) `write!(f, "{}", pprust::path_to_string(self))`
Path             | implementation       ref (88, 5) - (88, 9) `impl Path {`
from_ident       | method       def (91, 11) - (91, 21) `pub fn from_ident(s: Span, identifier: Ident) -> Path {`
vec              | call         ref (94, 22) - (94, 25) `segments: vec![PathSegment::from_ident(identifier, s)],`
default_to_global        | method       def (100, 11) - (100, 28) `pub fn default_to_global(mut self) -> Path {`
is_global        | call         ref (101, 17) - (101, 26) `if !self.is_global() {`
is_path_segment_keyword  | call         ref (103, 45) - (103, 68) `if !::parse::token::Ident(ident).is_path_segment_keyword() ||`
name             | call         ref (104, 45) - (104, 49) `ident.name == keywords::Crate.name() {`
insert           | call         ref (105, 30) - (105, 36) `self.segments.insert(0, PathSegment::crate_root(self.span));`
is_global        | method       def (111, 11) - (111, 20) `pub fn is_global(&self) -> bool {`
is_empty         | call         ref (112, 23) - (112, 31) `!self.segments.is_empty() && self.segments[0].identifier.name == keywords::CrateRoot.name()`
name             | call         ref (112, 93) - (112, 97) `!self.segments.is_empty() && self.segments[0].identifier.name == keywords::CrateRoot.name()`
PathSegment      | class        def (120, 11) - (120, 22) `pub struct PathSegment {`
PathSegment      | implementation       ref (135, 5) - (135, 16) `impl PathSegment {`
from_ident       | method       def (136, 11) - (136, 21) `pub fn from_ident(ident: Ident, span: Span) -> Self {`
crate_root       | method       def (139, 11) - (139, 21) `pub fn crate_root(span: Span) -> Self {`
ctxt             | call         ref (141, 43) - (141, 47) `identifier: Ident { ctxt: span.ctxt(), ..keywords::CrateRoot.ident() },`
ident            | call         ref (141, 73) - (141, 78) `identifier: Ident { ctxt: span.ctxt(), ..keywords::CrateRoot.ident() },`
PathParameters   | class        def (152, 9) - (152, 23) `pub enum PathParameters {`
PathParameters   | implementation       ref (159, 5) - (159, 19) `impl PathParameters {`
```