### PR TITLE
Add missing syntax highlighting queries for punctuation

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -60,6 +60,8 @@
 ")" @punctuation.bracket
 "[" @punctuation.bracket
 "]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
 
 (type_arguments
   "<" @punctuation.bracket
@@ -69,7 +71,9 @@
   ">" @punctuation.bracket)
 
 "::" @punctuation.delimiter
+":" @punctuation.delimiter
 "." @punctuation.delimiter
+"," @punctuation.delimiter
 ";" @punctuation.delimiter
 
 (parameter (identifier) @variable.parameter)


### PR DESCRIPTION
Add curly braces to punctuation.bracket
Add colon and comma to punctuation.delimiter

This addresses #123 
