### PR TITLE
Suppress `Wunused-parameter` warnings in scanner.c

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,6 +1,11 @@
 #include <tree_sitter/parser.h>
 #include <wctype.h>
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 enum TokenType {
   STRING_CONTENT,
   RAW_STRING_LITERAL,


### PR DESCRIPTION
When I compiled this project with [`cc` crate](https://crates.io/crates/cc), I got the following warnings.

```
warning: tree-sitter-rust/src/scanner.c:13:52: warning: unused parameter 'p' [-Wunused-parameter]
warning: void tree_sitter_rust_external_scanner_reset(void *p) {}
warning:                                                    ^
warning: tree-sitter-rust/src/scanner.c:14:60: warning: unused parameter 'p' [-Wunused-parameter]
warning: unsigned tree_sitter_rust_external_scanner_serialize(void *p, char *buffer) { return 0; }
warning:                                                            ^
warning: tree-sitter-rust/src/scanner.c:14:69: warning: unused parameter 'buffer' [-Wunused-parameter]
warning: unsigned tree_sitter_rust_external_scanner_serialize(void *p, char *buffer) { return 0; }
warning:                                                                     ^
warning: tree-sitter-rust/src/scanner.c:15:58: warning: unused parameter 'p' [-Wunused-parameter]
warning: void tree_sitter_rust_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
warning:                                                          ^
warning: tree-sitter-rust/src/scanner.c:15:73: warning: unused parameter 'b' [-Wunused-parameter]
warning: void tree_sitter_rust_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
warning:                                                                         ^
warning: tree-sitter-rust/src/scanner.c:15:85: warning: unused parameter 'n' [-Wunused-parameter]
warning: void tree_sitter_rust_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
warning:                                                                                     ^
warning: tree-sitter-rust/src/scanner.c:25:51: warning: unused parameter 'payload' [-Wunused-parameter]
warning: bool tree_sitter_rust_external_scanner_scan(void *payload, TSLexer *lexer,
warning:                                                   ^
warning: 7 warnings generated.
```

This PR suppresses them by disabling `Wunused-parameter` diagnostic.

If explicitly specifying unused parameters is preferred, please let me know. I'll update this patch. Though it causes repeat of attributes as follows:

```c
void tree_sitter_rust_external_scanner_deserialize(
    __attribute__((unused)) void *p,
    __attribute__((unused)) const char *b,
    __attribute__((unused)) unsigned n
) {}
```