### PR TITLE
Fix CI failure on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm install
       - run: npm test
   test_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
At some point in last year, label `windows-latest` started to run windows-2022 runner. However node-gyp (of Node.js v14) does not seem to support the latest Visual Studio. It is causing a current CI failure on Windows node. Using `windows-2019` label can fix the issue.

I confirmed CI passed on my fork: https://github.com/rhysd/tree-sitter-rust/runs/6335352791?check_suite_focus=true