### PR TITLE
Allow macro invocations in patterns

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -616,8 +616,8 @@ let msg = match x {
           pattern: (match_pattern
             (macro_invocation
               macro: (identifier)
-                (token_tree
-                  (integer_literal))))
+              (token_tree
+                (integer_literal))))
           value: (string_literal))
         (match_arm
           pattern: (match_pattern)

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -613,10 +613,11 @@ let msg = match x {
             (integer_literal))
           value: (string_literal))
         (match_arm
-          pattern: (macro_invocation
-            macro: (identifier)
-            (token_tree
-              (integer_literal)))
+          pattern: (match_pattern
+            (macro_invocation
+              macro: (identifier)
+                (token_tree
+                  (integer_literal))))
           value: (string_literal))
         (match_arm
           pattern: (match_pattern)

--- a/corpus/patterns.txt
+++ b/corpus/patterns.txt
@@ -243,6 +243,8 @@ let ref mut x @ (A | B | C);
 
 fn foo((1 | 2 | 3): u8) {}
 
+if let x!() | y!() = () {}
+
 // Discomment after box pattern land on master
 // let box (A | B | C);
 
@@ -366,6 +368,17 @@ fn foo((1 | 2 | 3): u8) {}
             (integer_literal)))
         type: (primitive_type)))
     body: (block))
+  (expression_statement
+    (if_let_expression
+      pattern: (or_pattern
+        (macro_invocation
+          macro: (identifier)
+          (token_tree))
+        (macro_invocation
+          macro: (identifier)
+          (token_tree)))
+      value: (unit_expression)
+      consequence: (block)))
   (line_comment)
   (line_comment)
   (line_comment)

--- a/grammar.js
+++ b/grammar.js
@@ -1216,10 +1216,7 @@ module.exports = grammar({
 
     match_arm: $ => seq(
       repeat($.attribute_item),
-      field('pattern', choice(
-        $.macro_invocation,
-        $.match_pattern
-      )),
+      field('pattern', $.match_pattern),
       '=>',
       choice(
         seq(field('value', $._expression), ','),
@@ -1358,6 +1355,7 @@ module.exports = grammar({
       $.range_pattern,
       $.or_pattern,
       $.const_block,
+      $.macro_invocation,
       '_'
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -768,7 +768,7 @@
         },
         {
           "type": "PATTERN",
-          "value": "[/_\\-=->,;:::!=?.@*&#%^+<>|~]+"
+          "value": "[\\/_\\-=->,;:::!=?.@*&#%^+<>|~]+"
         },
         {
           "type": "STRING",
@@ -7101,17 +7101,8 @@
           "type": "FIELD",
           "name": "pattern",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "macro_invocation"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "match_pattern"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "match_pattern"
           }
         },
         {
@@ -7966,6 +7957,10 @@
         {
           "type": "SYMBOL",
           "name": "const_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macro_invocation"
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -344,6 +344,10 @@
         "named": true
       },
       {
+        "type": "macro_invocation",
+        "named": true
+      },
+      {
         "type": "mut_pattern",
         "named": true
       },
@@ -2642,10 +2646,6 @@
         "multiple": false,
         "required": true,
         "types": [
-          {
-            "type": "macro_invocation",
-            "named": true
-          },
           {
             "type": "match_pattern",
             "named": true


### PR DESCRIPTION
Currently, macro invocations in patterns cause parsing errors.
This was partially addressed by #24, but the fix was not general enough to handle all cases.

Examples that do not currently parse correctly but are accepted by the compiler:
```rust
macro_rules! foo {
    () => {
        _
    };
}

fn main() {
    // Macro in a `let` pattern.
    let foo!() = 3;

    // More than one macro invocation in a `match` branch.
    match () {
        foo!() | foo!() => ()
    }
}
```

This results in the following output from `tree-sitter-cli parse`:
<details>
    <summary>Expand</summary>

    (source_file [0, 0] - [15, 0]
      (macro_definition [0, 0] - [4, 1]
        name: (identifier [0, 13] - [0, 16])
        (macro_rule [1, 4] - [3, 5]
          left: (token_tree_pattern [1, 4] - [1, 6])
          right: (token_tree [1, 10] - [3, 5])))
      (function_item [6, 0] - [14, 1]
        name: (identifier [6, 3] - [6, 7])
        parameters: (parameters [6, 7] - [6, 9])
        body: (block [6, 10] - [14, 1]
          (line_comment [7, 4] - [7, 32])
          (let_declaration [8, 4] - [8, 19]
            pattern: (tuple_struct_pattern [8, 8] - [8, 14]
              type: (identifier [8, 8] - [8, 11])
              (ERROR [8, 11] - [8, 12]))
            value: (integer_literal [8, 17] - [8, 18]))
          (line_comment [10, 4] - [10, 58])
          (expression_statement [11, 4] - [13, 5]
            (match_expression [11, 4] - [13, 5]
              value: (unit_expression [11, 10] - [11, 12])
              body: (match_block [11, 13] - [13, 5]
                (ERROR [12, 8] - [12, 30]
                  (macro_invocation [12, 8] - [12, 14]
                    macro: (identifier [12, 8] - [12, 11])
                    (token_tree [12, 12] - [12, 14]))
                  (match_arm [12, 17] - [12, 30]
                    pattern: (macro_invocation [12, 17] - [12, 23]
                      macro: (identifier [12, 17] - [12, 20])
                      (token_tree [12, 21] - [12, 23]))
                    value: (unit_expression [12, 27] - [12, 29])))))))))
    src/main.rs    0 ms    (ERROR [8, 11] - [8, 12])
    Total parses: 1; successful parses: 0; failed parses: 1; success percentage: 0.00%
</details>

After this patch, the example parses correctly:
<details>
    <summary>Expand</summary>

    (source_file [0, 0] - [15, 0]
      (macro_definition [0, 0] - [4, 1]
        name: (identifier [0, 13] - [0, 16])
        (macro_rule [1, 4] - [3, 5]
          left: (token_tree_pattern [1, 4] - [1, 6])
          right: (token_tree [1, 10] - [3, 5])))
      (function_item [6, 0] - [14, 1]
        name: (identifier [6, 3] - [6, 7])
        parameters: (parameters [6, 7] - [6, 9])
        body: (block [6, 10] - [14, 1]
          (line_comment [7, 4] - [7, 32])
          (let_declaration [8, 4] - [8, 19]
            pattern: (macro_invocation [8, 8] - [8, 14]
              macro: (identifier [8, 8] - [8, 11])
              (token_tree [8, 12] - [8, 14]))
            value: (integer_literal [8, 17] - [8, 18]))
          (line_comment [10, 4] - [10, 58])
          (expression_statement [11, 4] - [13, 5]
            (match_expression [11, 4] - [13, 5]
              value: (unit_expression [11, 10] - [11, 12])
              body: (match_block [11, 13] - [13, 5]
                (match_arm [12, 8] - [12, 30]
                  pattern: (match_pattern [12, 8] - [12, 23]
                    (or_pattern [12, 8] - [12, 23]
                      (macro_invocation [12, 8] - [12, 14]
                        macro: (identifier [12, 8] - [12, 11])
                        (token_tree [12, 12] - [12, 14]))
                      (macro_invocation [12, 17] - [12, 23]
                        macro: (identifier [12, 17] - [12, 20])
                        (token_tree [12, 21] - [12, 23]))))
                  value: (unit_expression [12, 27] - [12, 29]))))))))
    Total parses: 1; successful parses: 1; failed parses: 0; success percentage: 100.00%
</details>

The motivating example can be seen at https://github.com/helix-editor/helix/blob/e04bb8b8915bfe1df1a5ee7a8750f2589f2aae06/helix-term/src/ui/picker.rs#L502-L514 where there are multiple macro invocations per match branch, leading to incorrect syntax highlighting in an editor using tree-sitter-rust.

![image](https://user-images.githubusercontent.com/15171148/169655671-9598153e-64f2-492d-a589-305e7d7a0af5.png)
