### PR TITLE
Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 examples
 !examples/ast.rs
 /target/
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
                 ],
                 sources: [
                     "src/parser.c",
-                    "scanner.c",
+                    "src/scanner.c",
                 ],
                 resources: [
                     .copy("queries")

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterRust",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterRust", targets: ["TreeSitterRust"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterRust",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "examples",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "README.md",
+                    "script",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "scanner.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterRust/rust.h
+++ b/bindings/swift/TreeSitterRust/rust.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_RUST_H_
+#define TREE_SITTER_RUST_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_rust();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_RUST_H_


### PR DESCRIPTION
Swift's package manager can build C/C++ sources and use headers to expose functions to Swift. The standard tree-sitter parser project layout just requires a little extra configuration to make it happy.