### PR TITLE
Added tagging query binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples
 !examples/ast.rs
 /target/
 .build/
+/.idea/

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -49,6 +49,9 @@ pub const GRAMMAR: &str = include_str!("../../grammar.js");
 /// The syntax highlighting query for this language.
 pub const HIGHLIGHT_QUERY: &str = include_str!("../../queries/highlights.scm");
 
+/// The symbol tagging query for this language.
+pub const TAGGING_QUERY: &str = include_str!("../../queries/tags.scm");
+
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types


### PR DESCRIPTION
There's an `queries/tags.scm`, but it's not exported in the Rust bindings. I just added an export