### PR TITLE
Tweaks to code highlighting. Closes #149.

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -150,7 +150,6 @@
 (attribute_item) @attribute
 (inner_attribute_item) @attribute
 
-"as" @operator
 "*" @operator
 "&" @operator
 "'" @operator

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -12,10 +12,24 @@
   path: (scoped_identifier
     name: (identifier) @type))
  (#match? @type "^[A-Z]"))
+((scoped_type_identifier
+  path: (identifier) @type)
+ (#match? @type "^[A-Z]"))
+((scoped_type_identifier
+  path: (scoped_identifier
+    name: (identifier) @type))
+ (#match? @type "^[A-Z]"))
 
 ; Assume other uppercase names are enum constructors
 ((identifier) @constructor
  (#match? @constructor "^[A-Z]"))
+
+; Assume all qualified names in struct patterns are enum constructors. (They're
+; either that, or struct names; highlighting both as constructors seems to be
+; the less glaring choice of error, visually.)
+(struct_pattern
+  type: (scoped_type_identifier
+    name: (type_identifier) @constructor))
 
 ; Function calls
 
@@ -80,6 +94,9 @@
 
 (lifetime (identifier) @label)
 
+"as" @keyword
+"async" @keyword
+"await" @keyword
 "break" @keyword
 "const" @keyword
 "continue" @keyword
@@ -93,7 +110,6 @@
 "if" @keyword
 "impl" @keyword
 "in" @keyword
-"let" @keyword
 "let" @keyword
 "loop" @keyword
 "macro_rules!" @keyword
@@ -112,6 +128,7 @@
 "use" @keyword
 "where" @keyword
 "while" @keyword
+(crate) @keyword
 (mutable_specifier) @keyword
 (use_list (self) @keyword)
 (scoped_use_list (self) @keyword)


### PR DESCRIPTION
Issue #149 explains what I'm trying to fix here (in case you're not a big fan of spot-the-differences puzzles).

Before:
<img width="719" alt="image" src="https://user-images.githubusercontent.com/283361/179625209-b0ebe8a7-1e76-42f9-87ba-c4234ead5299.png">

After:
<img width="719" alt="image" src="https://user-images.githubusercontent.com/283361/179625114-85612bb3-af5c-4825-a0df-b0e0ba290dba.png">

I'm a new contributor here, so please let me know if there's a test suite, CONTRIBUTING file, etc. that I should be looking at.
