### PR TITLE
Fix the precedence of `as` casts

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -285,7 +285,7 @@ Type cast expressions
 
 1000 as u8;
 let character = integer as char;
-let size: f64 = len(values) as f64;
+let size: f64 = 1.0 + -len(values) as f64 + 1.0;
 
 --------------------------------------------------------------------------------
 
@@ -302,12 +302,17 @@ let size: f64 = len(values) as f64;
   (let_declaration
     pattern: (identifier)
     type: (primitive_type)
-    value: (type_cast_expression
-      value: (call_expression
-        function: (identifier)
-        arguments: (arguments
-          (identifier)))
-      type: (primitive_type))))
+    value: (binary_expression
+      left: (binary_expression
+        left: (float_literal)
+        right: (type_cast_expression
+          value: (unary_expression
+            (call_expression
+              function: (identifier)
+              arguments: (arguments
+                (identifier))))
+          type: (primitive_type)))
+      right: (float_literal))))
 
 ================================================================================
 Call expressions

--- a/grammar.js
+++ b/grammar.js
@@ -2,7 +2,8 @@ const PREC = {
   range: 15,
   call: 14,
   field: 13,
-  unary: 11,
+  unary: 12,
+  cast: 11,
   multiplicative: 10,
   additive: 9,
   shift: 8,
@@ -1074,11 +1075,11 @@ module.exports = grammar({
       field('right', $._expression)
     )),
 
-    type_cast_expression: $ => seq(
+    type_cast_expression: $ => prec.left(PREC.cast, seq(
       field('value', $._expression),
       'as',
       field('type', $._type)
-    ),
+    )),
 
     return_expression: $ => choice(
       prec.left(seq('return', $._expression)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5798,7 +5798,7 @@
     },
     "unary_expression": {
       "type": "PREC",
-      "value": 11,
+      "value": 12,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5841,7 +5841,7 @@
     },
     "reference_expression": {
       "type": "PREC",
-      "value": 11,
+      "value": 12,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6334,29 +6334,33 @@
       }
     },
     "type_cast_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_expression"
+      "type": "PREC_LEFT",
+      "value": 11,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "value",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "as"
+          },
+          {
+            "type": "FIELD",
+            "name": "type",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_type"
+            }
           }
-        },
-        {
-          "type": "STRING",
-          "value": "as"
-        },
-        {
-          "type": "FIELD",
-          "name": "type",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_type"
-          }
-        }
-      ]
+        ]
+      }
     },
     "return_expression": {
       "type": "CHOICE",


### PR DESCRIPTION
I noticed this was missing. `as` is documented as having precedence between unary operators and multiplicative operators.