### PR TITLE
Support let-else statements

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -432,7 +432,7 @@ let u32: str = "";
     (string_literal)))
 
 ================================================================================
-let-else Statements
+Let-else Statements
 ================================================================================
 
 let Foo::Bar {
@@ -454,44 +454,70 @@ let Some(x) = y else {
 
 (source_file
   (let_declaration
-    (struct_pattern
-      (scoped_type_identifier
-        (identifier)
-        (type_identifier))
+    pattern: (struct_pattern
+      type: (scoped_type_identifier
+        path: (identifier)
+        name: (type_identifier))
       (field_pattern
-        (shorthand_field_identifier))
+        name: (shorthand_field_identifier))
       (field_pattern
-        (shorthand_field_identifier)))
-      (try_expression
-        (await_expression
-          (call_expression
-            (field_expression
-              (call_expression
-                (identifier)
-                (arguments))
-              (field_identifier))
-            (arguments))))
-        (block
-          (return_expression
-            (call_expression
-              (identifier)
-              (arguments (identifier))))))
+        name: (shorthand_field_identifier)))
+    value: (try_expression
+      (await_expression
+        (call_expression
+          function: (field_expression
+            value: (call_expression
+              function: (identifier)
+              arguments: (arguments))
+            field: (field_identifier))
+          arguments: (arguments))))
+    alternative: (block
+      (return_expression
+        (call_expression
+          function: (identifier)
+          arguments: (arguments
+            (identifier))))))
   (let_declaration
-    (tuple_struct_pattern
-      (identifier)
+    pattern: (tuple_struct_pattern
+      type: (identifier)
       (identifier))
-    (identifier)
-    (block
+    value: (identifier)
+    alternative: (block
       (let_declaration
-        (identifier)
-        (identifier)
-        (block
+        pattern: (identifier)
+        value: (identifier)
+        alternative: (block
           (expression_statement
             (call_expression
-              (identifier)
-              (arguments)))
-          (expression_statement (break_expression))))
-    (expression_statement (continue_expression)))))
+              function: (identifier)
+              arguments: (arguments)))
+          (expression_statement
+            (break_expression))))
+      (expression_statement
+        (continue_expression)))))
+
+================================================================================
+Let declarations with if expressions as the value
+================================================================================
+
+let a = if b {
+    c
+} else {
+    d
+};
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (let_declaration
+    (identifier)
+    (if_expression
+      (identifier)
+      (block
+        (identifier))
+      (else_clause
+        (block
+          (identifier))))))
 
 ================================================================================
 Structs
@@ -1108,27 +1134,31 @@ foo(#[bar(some tokens are special in other contexts: $/';()*()+.)] x);
     (call_expression
       function: (identifier)
       arguments: (arguments
-        (attribute_item (attr_item
-          (identifier)
-          arguments: (token_tree (identifier) (identifier))))
+        (attribute_item
+          (attr_item
+            (identifier)
+            arguments: (token_tree
+              (identifier)
+              (identifier))))
         (identifier)
         (identifier))))
   (expression_statement
     (call_expression
       function: (identifier)
       arguments: (arguments
-        (attribute_item (attr_item
-          (identifier)
-          arguments: (token_tree
+        (attribute_item
+          (attr_item
             (identifier)
-            (identifier)
-            (identifier)
-            (identifier)
-            (identifier)
-            (identifier)
-            (identifier)
-            (token_tree)
-            (token_tree))))
+            arguments: (token_tree
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (token_tree)
+              (token_tree))))
         (identifier)))))
 
 ================================================================================
@@ -1152,36 +1182,51 @@ pub enum Error {
 (source_file
   (line_comment)
   (use_declaration
-    (scoped_identifier (identifier) (identifier)))
+    (scoped_identifier
+      (identifier)
+      (identifier)))
   (attribute_item
-    (meta_item (identifier)
+    (meta_item
+      (identifier)
       (meta_arguments
-        (meta_item (identifier))
-        (meta_item (identifier)))))
+        (meta_item
+          (identifier))
+        (meta_item
+          (identifier)))))
   (enum_item
     (visibility_modifier)
     (type_identifier)
     (enum_variant_list
-      (attribute_item (attr_item
+      (attribute_item
+        (attr_item
+          (identifier)
+          (token_tree
+            (string_literal)
+            (identifier)
+            (token_tree
+              (integer_literal)))))
+      (enum_variant
         (identifier)
-        (token_tree
-          (string_literal)
+        (ordered_field_declaration_list
+          (type_identifier)))
+      (attribute_item
+        (attr_item
           (identifier)
-          (token_tree (integer_literal)))))
-      (enum_variant (identifier)
-        (ordered_field_declaration_list (type_identifier)))
-      (attribute_item (attr_item
+          (token_tree
+            (string_literal)
+            (identifier)
+            (identifier)
+            (identifier)
+            (identifier))))
+      (enum_variant
         (identifier)
-        (token_tree
-          (string_literal)
-          (identifier)
-          (identifier)
-          (identifier)
-          (identifier))))
-      (enum_variant (identifier)
         (field_declaration_list
-          (field_declaration (field_identifier) (primitive_type))
-          (field_declaration (field_identifier) (type_identifier)))))))
+          (field_declaration
+            (field_identifier)
+            (primitive_type))
+          (field_declaration
+            (field_identifier)
+            (type_identifier)))))))
 
 ================================================================================
 Attributes and Expressions

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -432,6 +432,68 @@ let u32: str = "";
     (string_literal)))
 
 ================================================================================
+let-else Statements
+================================================================================
+
+let Foo::Bar {
+    texts,
+    values,
+} = foo().bar().await? else {
+    return Err(index)
+};
+
+let Some(x) = y else {
+    let None = z else {
+        foo();
+        break;
+    };
+    continue;
+};
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (let_declaration
+    (struct_pattern
+      (scoped_type_identifier
+        (identifier)
+        (type_identifier))
+      (field_pattern
+        (shorthand_field_identifier))
+      (field_pattern
+        (shorthand_field_identifier)))
+      (try_expression
+        (await_expression
+          (call_expression
+            (field_expression
+              (call_expression
+                (identifier)
+                (arguments))
+              (field_identifier))
+            (arguments))))
+        (block
+          (return_expression
+            (call_expression
+              (identifier)
+              (arguments (identifier))))))
+  (let_declaration
+    (tuple_struct_pattern
+      (identifier)
+      (identifier))
+    (identifier)
+    (block
+      (let_declaration
+        (identifier)
+        (identifier)
+        (block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments)))
+          (expression_statement (break_expression))))
+    (expression_statement (continue_expression)))))
+
+================================================================================
 Structs
 ================================================================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -125,6 +125,8 @@ module.exports = grammar({
     [$.parameters, $._pattern],
     [$.parameters, $.tuple_struct_pattern],
     [$.type_parameters, $.for_lifetimes],
+    [$.if_expression],
+    [$.if_let_expression],
   ],
 
   word: $ => $.identifier,
@@ -632,6 +634,10 @@ module.exports = grammar({
       optional(seq(
         '=',
         field('value', $._expression)
+      )),
+      optional(seq(
+        'else',
+        field('let_else_block', $.block)
       )),
       ';'
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -125,8 +125,6 @@ module.exports = grammar({
     [$.parameters, $._pattern],
     [$.parameters, $.tuple_struct_pattern],
     [$.type_parameters, $.for_lifetimes],
-    [$.if_expression],
-    [$.if_let_expression],
   ],
 
   word: $ => $.identifier,
@@ -637,7 +635,7 @@ module.exports = grammar({
       )),
       optional(seq(
         'else',
-        field('let_else_block', $.block)
+        field('alternative', $.block)
       )),
       ';'
     ),
@@ -1180,14 +1178,14 @@ module.exports = grammar({
       $._expression
     ),
 
-    if_expression: $ => seq(
+    if_expression: $ => prec.right(seq(
       'if',
       field('condition', $._expression),
       field('consequence', $.block),
       optional(field("alternative", $.else_clause))
-    ),
+    )),
 
-    if_let_expression: $ => seq(
+    if_let_expression: $ => prec.right(seq(
       'if',
       'let',
       field('pattern', $._pattern),
@@ -1195,7 +1193,7 @@ module.exports = grammar({
       field('value', $._expression),
       field('consequence', $.block),
       optional(field('alternative', $.else_clause))
-    ),
+    )),
 
     else_clause: $ => seq(
       'else',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -768,7 +768,7 @@
         },
         {
           "type": "PATTERN",
-          "value": "[\\/_\\-=->,;:::!=?.@*&#%^+<>|~]+"
+          "value": "[/_\\-=->,;:::!=?.@*&#%^+<>|~]+"
         },
         {
           "type": "STRING",
@@ -3673,6 +3673,31 @@
                   "content": {
                     "type": "SYMBOL",
                     "name": "_expression"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "else"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "let_else_block",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "block"
                   }
                 }
               ]
@@ -9044,6 +9069,12 @@
     [
       "type_parameters",
       "for_lifetimes"
+    ],
+    [
+      "if_expression"
+    ],
+    [
+      "if_let_expression"
     ]
   ],
   "precedences": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3694,7 +3694,7 @@
                 },
                 {
                   "type": "FIELD",
-                  "name": "let_else_block",
+                  "name": "alternative",
                   "content": {
                     "type": "SYMBOL",
                     "name": "block"
@@ -6926,102 +6926,110 @@
       ]
     },
     "if_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "if"
-        },
-        {
-          "type": "FIELD",
-          "name": "condition",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_expression"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "consequence",
-          "content": {
-            "type": "SYMBOL",
-            "name": "block"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "alternative",
-              "content": {
-                "type": "SYMBOL",
-                "name": "else_clause"
-              }
-            },
-            {
-              "type": "BLANK"
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "if"
+          },
+          {
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
             }
-          ]
-        }
-      ]
+          },
+          {
+            "type": "FIELD",
+            "name": "consequence",
+            "content": {
+              "type": "SYMBOL",
+              "name": "block"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "alternative",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "else_clause"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "if_let_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "if"
-        },
-        {
-          "type": "STRING",
-          "value": "let"
-        },
-        {
-          "type": "FIELD",
-          "name": "pattern",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_pattern"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "="
-        },
-        {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_expression"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "consequence",
-          "content": {
-            "type": "SYMBOL",
-            "name": "block"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "alternative",
-              "content": {
-                "type": "SYMBOL",
-                "name": "else_clause"
-              }
-            },
-            {
-              "type": "BLANK"
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "if"
+          },
+          {
+            "type": "STRING",
+            "value": "let"
+          },
+          {
+            "type": "FIELD",
+            "name": "pattern",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pattern"
             }
-          ]
-        }
-      ]
+          },
+          {
+            "type": "STRING",
+            "value": "="
+          },
+          {
+            "type": "FIELD",
+            "name": "value",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "consequence",
+            "content": {
+              "type": "SYMBOL",
+              "name": "block"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "alternative",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "else_clause"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "else_clause": {
       "type": "SEQ",
@@ -9069,12 +9077,6 @@
     [
       "type_parameters",
       "for_lifetimes"
-    ],
-    [
-      "if_expression"
-    ],
-    [
-      "if_let_expression"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2458,6 +2458,16 @@
     "type": "let_declaration",
     "named": true,
     "fields": {
+      "let_else_block": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      },
       "pattern": {
         "multiple": false,
         "required": true,

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2458,7 +2458,7 @@
     "type": "let_declaration",
     "named": true,
     "fields": {
-      "let_else_block": {
+      "alternative": {
         "multiple": false,
         "required": false,
         "types": [


### PR DESCRIPTION
`let_else` feature is going to be stabilized on Rust 1.65.0.
This PR adds support for it.