### PR TITLE
Add enum member support to tags.scm

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -6,6 +6,9 @@
 (enum_item
     name: (type_identifier) @name) @definition.class
 
+(enum_variant
+    name: (identifier) @name) @definition.class
+
 (union_item
     name: (type_identifier) @name) @definition.class
 


### PR DESCRIPTION
Adds a tag for enum members. Currently using the semantic name `definition.class` since it's already being used for `enum_item` and seems to most closely align with this property when choosing [from the current capture names](https://github.com/tree-sitter/tree-sitter/blob/fb5fbdd78700b20754da5e6b4f2b4317a912e2d2/docs/section-8-code-navigation-systems.md?plain=1#L65-L76).

We discussed potentially adding a few new capture names that would better represent algebraic data types and enums, ie. `definition.case` or `definition.constructor` for `enum_variant` and `definition.adt` or `definition.enum` for `enum_item`. Opening this PR to continue the conversation here.

cc @tree-sitter/semantic-code 