### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ Rust grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter)
 
 * [The Rust Grammar Reference](https://doc.rust-lang.org/grammar.html) - The grammar reference provides chapters that formally define the language grammar.
 * [The Rust Reference](https://doc.rust-lang.org/reference/) - While Rust does not have a specification, the reference tries to describe its working in detail. It tends to be out of date.
-* [Keywords](https://doc.rust-lang.org/stable/book/appendix-01-keywords.html) and [Operators and Symbols](https://doc.rust-lang.org/stable/book/appendix-02-operators.html)
+* [Keywords](https://doc.rust-lang.org/stable/book/appendix-01-keywords.html) and [Operators and Symbols](https://doc.rust-lang.org/stable/book/appendix-02-operators.html).
 * Archive of the outdated [Syntax Index](https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/book/first-edition/syntax-index.html) that contains examples of all syntax in Rust cross-referenced with the section of The Book that describes it.

--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ Rust grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter)
 
 * [The Rust Grammar Reference](https://doc.rust-lang.org/grammar.html) - The grammar reference provides chapters that formally define the language grammar.
 * [The Rust Reference](https://doc.rust-lang.org/reference/) - While Rust does not have a specification, the reference tries to describe its working in detail. It tends to be out of date.
-* [Syntax Index](https://doc.rust-lang.org/book/first-edition/syntax-index.html) - This appendix from The Book contains examples of all syntax in Rust cross-referenced with the section of The Book that describes it.
+* [Keywords](https://doc.rust-lang.org/stable/book/appendix-01-keywords.html) and [Operators and Symbols](https://doc.rust-lang.org/stable/book/appendix-02-operators.html)
+* Archive of the outdated [Syntax Index](https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/book/first-edition/syntax-index.html) that contains examples of all syntax in Rust cross-referenced with the section of The Book that describes it.


### PR DESCRIPTION
The `Syntax Index` link was broken. It seems that the up-to-date replacement for this information is found in `Keywords` and `Operators and Symbols`, but it misses the cross-referencing. I added the new links, and found an archived replacement for the old one.

I don't know this subject well so I might be totally wrong on this, so feel free to ignore if you like.