### PR TITLE
Add an action to publish the grammar automatically

### DIFF
--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -1,0 +1,33 @@
+name: Publish on crates.io
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Verify publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          dry-run: true
+
+      - name: Publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This PR allows to publish automatically `tree-sitter-rust` on `crates.io` when a new tag is set.

Thanks in advance for your review! :)