### PR TITLE
Correct CI badge reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tree-sitter-rust
 
-[![CI](https://github.com/tree-sitter/tree-sitter-c/actions/workflows/ci.yml/badge.svg)](https://github.com/tree-sitter/tree-sitter-c/actions/workflows/ci.yml)
+[![CI](https://github.com/tree-sitter/tree-sitter-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/tree-sitter/tree-sitter-rust/actions/workflows/ci.yml)
 
 Rust grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter)
 


### PR DESCRIPTION
Badge wrongly referenced `tree-sitter-c` before, changed to `tree-sitter-rust`.
Now badge shows CI status of Rust grammar, not C.