### PR TITLE
Support Doc Comments and General Cleanup of Scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 !examples/ast.rs
 !examples/weird-exprs.rs
 /target/
+/fuzzer/

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -70,6 +70,9 @@
 (line_comment) @comment
 (block_comment) @comment
 
+(line_comment (doc_comment)) @comment.documentation
+(block_comment (doc_comment)) @comment.documentation
+
 "(" @punctuation.bracket
 ")" @punctuation.bracket
 "[" @punctuation.bracket

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8591,20 +8591,189 @@
       ]
     },
     "line_comment": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "//"
-          },
-          {
-            "type": "PATTERN",
-            "value": ".*"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "//"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "\\/\\/"
+                    }
+                  }
+                },
+                {
+                  "type": "PATTERN",
+                  "value": ".*"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "doc",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_line_doc_comment"
+                    },
+                    "named": true,
+                    "value": "doc_comment"
+                  }
+                },
+                {
+                  "type": "PATTERN",
+                  "value": ".*"
+                }
+              ]
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PREC",
+                "value": 1,
+                "content": {
+                  "type": "PATTERN",
+                  "value": ".*"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "_line_doc_comment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "outer",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_outer_line_doc_comment"
+            },
+            "named": true,
+            "value": "outer_doc_comment"
           }
-        ]
+        },
+        {
+          "type": "FIELD",
+          "name": "inner",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_inner_line_doc_comment"
+            },
+            "named": true,
+            "value": "inner_doc_comment"
+          }
+        }
+      ]
+    },
+    "_inner_line_doc_comment": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 2,
+        "content": {
+          "type": "STRING",
+          "value": "!"
+        }
       }
+    },
+    "_outer_line_doc_comment": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 2,
+        "content": {
+          "type": "PATTERN",
+          "value": "\\/[^\\/]"
+        }
+      }
+    },
+    "block_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/*"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "doc",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_block_doc_comment"
+                },
+                "named": true,
+                "value": "doc_comment"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "*/"
+        }
+      ]
+    },
+    "_block_doc_comment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inner",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_inner_block_doc_comment"
+            },
+            "named": true,
+            "value": "inner_doc_comment"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "outer",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_outer_block_doc_comment"
+            },
+            "named": true,
+            "value": "outer_doc_comment"
+          }
+        }
+      ]
     },
     "_path": {
       "type": "CHOICE",
@@ -8837,7 +9006,19 @@
     },
     {
       "type": "SYMBOL",
-      "name": "block_comment"
+      "name": "_outer_block_doc_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_inner_block_doc_comment"
+    },
+    {
+      "type": "STRING",
+      "value": "*/"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_error_sentinel"
     }
   ],
   "inline": [
@@ -8859,4 +9040,3 @@
     "_pattern"
   ]
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -882,6 +882,22 @@
     }
   },
   {
+    "type": "block_comment",
+    "named": true,
+    "fields": {
+      "doc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "doc_comment",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "boolean_literal",
     "named": true,
     "fields": {}
@@ -1449,6 +1465,32 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "doc_comment",
+    "named": true,
+    "fields": {
+      "inner": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "inner_doc_comment",
+            "named": true
+          }
+        ]
+      },
+      "outer": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "outer_doc_comment",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -2587,6 +2629,22 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "line_comment",
+    "named": true,
+    "fields": {
+      "doc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "doc_comment",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4836,6 +4894,10 @@
     "named": false
   },
   {
+    "type": "*/",
+    "named": false
+  },
+  {
     "type": "*=",
     "named": false
   },
@@ -4881,6 +4943,14 @@
   },
   {
     "type": "/",
+    "named": false
+  },
+  {
+    "type": "/*",
+    "named": false
+  },
+  {
+    "type": "//",
     "named": false
   },
   {
@@ -4992,10 +5062,6 @@
     "named": false
   },
   {
-    "type": "block_comment",
-    "named": true
-  },
-  {
     "type": "break",
     "named": false
   },
@@ -5084,6 +5150,10 @@
     "named": false
   },
   {
+    "type": "inner_doc_comment",
+    "named": true
+  },
+  {
     "type": "integer_literal",
     "named": true
   },
@@ -5098,10 +5168,6 @@
   {
     "type": "lifetime",
     "named": false
-  },
-  {
-    "type": "line_comment",
-    "named": true
   },
   {
     "type": "literal",
@@ -5137,6 +5203,10 @@
   },
   {
     "type": "mutable_specifier",
+    "named": true
+  },
+  {
+    "type": "outer_doc_comment",
     "named": true
   },
   {

--- a/test/corpus/source_files.txt
+++ b/test/corpus/source_files.txt
@@ -8,10 +8,23 @@ Block comments
 
 /* Comment with asterisks **/
 
+/** Outer block comment */
+
+
+/*! Inner block comment */
+/**/
+
 ----
 
 (source_file
   (block_comment)
+  (block_comment)
+  (block_comment
+    doc: (doc_comment
+      outer: (outer_doc_comment)))
+  (block_comment
+    doc: (doc_comment
+      inner: (inner_doc_comment)))
   (block_comment))
 
 ============================================
@@ -28,7 +41,8 @@ Nested block comments
 
 /****
   /****
-    nested with extra stars
+    nested with extra stars which makes it a regular block comment
+    and not a block doc comment
   ****/
 ****/
 
@@ -50,10 +64,123 @@ Line comments
 
 // Comment
 
+/// Outer line doc comment
+
+//! Inner line doc comment
+
 ----
 
 (source_file
+  (line_comment)
+  (line_comment
+    doc: (doc_comment
+      outer: (outer_doc_comment)))
+  (line_comment
+    doc: (doc_comment
+      inner: (inner_doc_comment))))
+
+====================================
+Line doc comments
+====================================
+//!  - Inner line doc
+//!! - Still an inner line doc (but with a bang at the beginning)
+
+//   - Only a comment
+///  - Outer line doc (exactly 3 slashes)
+//// - Only a comment
+
+---
+
+(source_file
+  (line_comment
+    doc: (doc_comment
+      inner: (inner_doc_comment)))
+  (line_comment
+    doc: (doc_comment
+      inner: (inner_doc_comment)))
+
+  (line_comment)
+  (line_comment
+    doc: (doc_comment
+      outer: (outer_doc_comment)))
   (line_comment))
+
+====================================
+Block doc comments
+====================================
+
+/*!  - Inner block doc */
+/*!! - Still an inner block doc (but with a bang at the beginning) */
+
+/*   - Only a comment */
+/**  - Outer block doc (exactly) 2 asterisks */
+/*** - Only a comment */
+
+----
+
+(source_file
+  (block_comment
+    (doc_comment
+      (inner_doc_comment)))
+  (block_comment
+    (doc_comment
+      (inner_doc_comment)))
+  (block_comment)
+  (block_comment
+    (doc_comment
+      (outer_doc_comment)))
+  (block_comment))
+
+=====================================
+Nested doc block comments
+=====================================
+
+/*   /* */  /** */  /*! */  */
+/*!  /* */  /** */  /*! */  */
+/**  /* */  /** */  /*! */  */
+
+----
+
+(source_file
+  (block_comment)
+  (block_comment
+    (doc_comment
+      (inner_doc_comment)))
+  (block_comment
+    (doc_comment
+      (outer_doc_comment))))
+
+====================================
+Comments degenerate cases
+====================================
+
+//!
+
+/*!*/
+
+//
+
+///
+
+/**/
+
+/***/
+
+----
+
+(source_file
+  (line_comment
+    (doc_comment
+      (inner_doc_comment)))
+  (block_comment
+    (doc_comment
+      (inner_doc_comment)))
+  (line_comment)
+  (line_comment
+    (doc_comment
+      (outer_doc_comment)))
+  (block_comment)
+  (block_comment))
 
 =====================================
 Greek letters in identifiers


### PR DESCRIPTION
Hi all! 

I was looking at some previous PRs for doc comments like #168 and thought I would take a crack at it addressing some of the issues raised by @the-mikedavis in the other PR to fix #147. I scope creeped myself while I was doing it though and also separated each of the processing steps in the scanner.c file out into their own functions to make it easier to read the file. I was struggling quite a bit to read it myself. I also went through and did some cleanup of functions based on what I read in the documentation for tree-sitter.

If I need to split this into 2 separate PRs, let me know, and I will address that as able. 

Quick question though, is there a good way for me to benchmark my changes against the original solution? I want to make sure that the extra processing cost we would be incurring is worth it. 

## Changes Made

### Grammar
- Added an error sentinel value to the externals array. See the comments in the scanner.c for explanation.
- Changed from handling the entirety of block comment parsing in the external scanner to just the inner block/outer block signifier scanning and the block comment ending scanning
- Split the line comment into 3 cases. 
    1. The line starts with 4 or more slashes which makes what looks like a doc comment actually a regular comment
    2. The line starts with 2 slashes and either one more slash or at least 1 bang which makes the comment a regular comment
    3. The line starts with only 2 slashes and everything after that is content
- Added hidden rules for line doc comment, line inner doc comment, and line outer doc comment to be used in aliases when scanning a line comment
- Added hidden rules for block doc comment, and external scanner handling for block inner and outer doc comment detection.
- Aliased the line doc comment and block doc comment to a generic doc comment node
- Aliased the inner line and block comment nodes to a generic inner doc comment node
- Aliased the outer line and block comment nodes to a generic outer doc comment node

### Scanner
- Switched everywhere where the code was using `lexer->lookahead == 0` to instead use `eof(lexer)` which calls the `eof` function on the lexer. This is recommended in the tree-sitter documentation I read.
- Added a `skip` function similar to the `advance` function and switched parts of the code from manually calling `advance` on the `lexer` to using either the `advance` function or the `skip` function.
- Added a `markEnd` function for the same reason as above. 
- Converted the block comment processing from a flag boolean to using an enum based state machine. It made it easier for me to read and catch edge cases. 
- In the block comment processing, I now first check whether there's a signifier of one of the doc comment possibilities and if there is I return the correct one. If there isn't, then I just pass it to the block comment processing part of the process function and completely parse the block comment and then return it with the end marked correctly.
- In block comment processing, previously, the behavior if an EOF was found was to return false. I changed that to return true. This is because for the purposes of tree sitting, if we found an EOF that means we are dealing with an unterminated block comment and the user likely wants that highlighted. If we were the rust parser obviously we would probably choose a different behavior but for our purposes here that behavior seems more reasonable to me. However, I'm more than willing to revert that change. I will need to just change a line or two. 
- Started using `markEnd` during the block comment processing and moved the block comment processing to the beginning of the scanner function to ensure that we don't skip over whitespace by accident.
- Added inlines to the lexer caller functions. Not sure that's actually worth it but it's there now. I can remove it if desired.

### Test
- Added tests for all the cases that I saw in the previous PRs. If there's any that I missed that you think I need to double check, feel free to include them and I will attempt to correct them at my earliest convenience. 