### PR TITLE
feat: Add a content field and element to raw string literals.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -68,7 +68,9 @@ module.exports = grammar({
 
   externals: $ => [
     $._string_content,
-    $.raw_string_literal,
+    $._raw_string_literal_open,
+    $.raw_string_literal_content,
+    $._raw_string_literal_close,
     $.float_literal,
     $.block_comment,
   ],
@@ -1438,12 +1440,18 @@ module.exports = grammar({
       optional(choice(...numeric_types)),
     )),
 
+    raw_string_literal: $ => seq(
+      $._raw_string_literal_open,
+      field('content', $.raw_string_literal_content),
+      $._raw_string_literal_close,
+    ),
+
     string_literal: $ => seq(
       alias(/b?"/, '"'),
-      repeat(choice(
+      field('content', repeat(choice(
         $.escape_sequence,
         $._string_content,
-      )),
+      ))),
       token.immediate('"'),
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -68,9 +68,9 @@ module.exports = grammar({
 
   externals: $ => [
     $._string_content,
-    $._raw_string_literal_open,
+    $._raw_string_literal_start,
     $.raw_string_literal_content,
-    $._raw_string_literal_close,
+    $._raw_string_literal_end,
     $.float_literal,
     $.block_comment,
   ],
@@ -1441,9 +1441,9 @@ module.exports = grammar({
     )),
 
     raw_string_literal: $ => seq(
-      $._raw_string_literal_open,
+      $._raw_string_literal_start,
       field('content', $.raw_string_literal_content),
-      $._raw_string_literal_close,
+      $._raw_string_literal_end,
     ),
 
     string_literal: $ => seq(

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -12,7 +12,7 @@ enum TokenType {
 };
 
 struct ScannerState {
-  unsigned opening_hash_count;
+  uint32_t opening_hash_count;
 };
 
 static struct ScannerState initial_state;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -11,35 +11,36 @@ enum TokenType {
   BLOCK_COMMENT,
 };
 
-struct ScannerState {
-  uint32_t opening_hash_count;
-};
+/// Stores the state of this external scanner for serialization.
+typedef struct RustScannerState {
+  uint32_t opening_hash_count; ///< Nr of '#' at the start of a raw string literal.
+} Scanner;
 
-static struct ScannerState initial_state;
+static Scanner initial_state;
 
 void *tree_sitter_rust_external_scanner_create() {
-  struct ScannerState *state = malloc(sizeof(struct ScannerState));
+  Scanner *state = malloc(sizeof(Scanner));
   *state = initial_state;
   return state;
 }
 
 void tree_sitter_rust_external_scanner_destroy(void *p) {
-  struct ScannerState *state = p;
+  Scanner *state = p;
   free(state);
 }
 
 void tree_sitter_rust_external_scanner_reset(void *p) {}
 
 unsigned tree_sitter_rust_external_scanner_serialize(void *p, char *buffer) {
-  memcpy(buffer, p, sizeof(struct ScannerState));
-  return sizeof(struct ScannerState);
+  memcpy(buffer, p, sizeof(Scanner));
+  return sizeof(Scanner);
 }
 
 void tree_sitter_rust_external_scanner_deserialize(void *p, const char *b, unsigned n) {
-  struct ScannerState *state = p;
+  Scanner *state = p;
   *state = initial_state;
-  if (n < sizeof(struct ScannerState)) return;
-  memcpy(state, b, sizeof(struct ScannerState));
+  if (n < sizeof(Scanner)) return;
+  memcpy(state, b, sizeof(Scanner));
 }
 
 static void advance(TSLexer *lexer) {
@@ -52,7 +53,7 @@ static bool is_num_char(int32_t c) {
 
 bool tree_sitter_rust_external_scanner_scan(void *payload, TSLexer *lexer,
                                             const bool *valid_symbols) {
-  struct ScannerState *state = payload;
+  Scanner *state = payload;
 
   if (valid_symbols[STRING_CONTENT] && !valid_symbols[FLOAT_LITERAL]) {
     bool has_content = false;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -4,9 +4,9 @@
 
 enum TokenType {
   STRING_CONTENT,
-  RAW_STRING_LITERAL_OPEN,
+  RAW_STRING_LITERAL_START,
   RAW_STRING_LITERAL_CONTENT,
-  RAW_STRING_LITERAL_CLOSE,
+  RAW_STRING_LITERAL_END,
   FLOAT_LITERAL,
   BLOCK_COMMENT,
 };
@@ -72,10 +72,10 @@ bool tree_sitter_rust_external_scanner_scan(void *payload, TSLexer *lexer,
   while (iswspace(lexer->lookahead)) lexer->advance(lexer, true);
 
   if (
-    valid_symbols[RAW_STRING_LITERAL_OPEN] &&
+    valid_symbols[RAW_STRING_LITERAL_START] &&
     (lexer->lookahead == 'r' || lexer->lookahead == 'b')
   ) {
-    lexer->result_symbol = RAW_STRING_LITERAL_OPEN;
+    lexer->result_symbol = RAW_STRING_LITERAL_START;
     if (lexer->lookahead == 'b') advance(lexer);
     if (lexer->lookahead != 'r') return false;
     advance(lexer);
@@ -93,9 +93,7 @@ bool tree_sitter_rust_external_scanner_scan(void *payload, TSLexer *lexer,
     return true;
   }
 
-  if (
-    valid_symbols[RAW_STRING_LITERAL_CONTENT]
-  ) {
+  if (valid_symbols[RAW_STRING_LITERAL_CONTENT]) {
     lexer->result_symbol = RAW_STRING_LITERAL_CONTENT;
 
     for (;;) {
@@ -121,8 +119,8 @@ bool tree_sitter_rust_external_scanner_scan(void *payload, TSLexer *lexer,
     }
   }
 
-  if (valid_symbols[RAW_STRING_LITERAL_CLOSE]) {
-    lexer->result_symbol = RAW_STRING_LITERAL_CLOSE;
+  if (valid_symbols[RAW_STRING_LITERAL_END]) {
+    lexer->result_symbol = RAW_STRING_LITERAL_END;
 
     if (lexer->lookahead == '"') {
       advance(lexer);

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -117,20 +117,37 @@ r#"abc"#; r##"ok"##;
 r##"foo #"# bar"##;
 r###"foo ##"## bar"###;
 r######"foo ##### bar"######;
+r######"fo
+
+sdfdsafasdf
+
+o ##### bar"######;
+r#""#;
 
 --------------------------------------------------------------------------------
 
 (source_file
   (expression_statement
-    (raw_string_literal))
+    (raw_string_literal
+      content: (raw_string_literal_content)))
   (expression_statement
-    (raw_string_literal))
+    (raw_string_literal
+      content: (raw_string_literal_content)))
   (expression_statement
-    (raw_string_literal))
+    (raw_string_literal
+      content: (raw_string_literal_content)))
   (expression_statement
-    (raw_string_literal))
+    (raw_string_literal
+      content: (raw_string_literal_content)))
   (expression_statement
-    (raw_string_literal)))
+    (raw_string_literal
+      content: (raw_string_literal_content)))
+  (expression_statement
+    (raw_string_literal
+      content: (raw_string_literal_content)))
+  (expression_statement
+    (raw_string_literal
+      content: (raw_string_literal_content))))
 
 ================================================================================
 Raw byte string literals
@@ -138,14 +155,29 @@ Raw byte string literals
 
 br#"abc"#;
 br##"abc"##;
+br##""##;
+br#####"abc
+asdfadfg41029367'äöö3247<234trdfg
+"##
+
+asdf
+"#####;
 
 --------------------------------------------------------------------------------
 
 (source_file
   (expression_statement
-    (raw_string_literal))
+    (raw_string_literal
+      content: (raw_string_literal_content)))
   (expression_statement
-    (raw_string_literal)))
+    (raw_string_literal
+      content: (raw_string_literal_content)))
+  (expression_statement
+    (raw_string_literal
+      content: (raw_string_literal_content)))
+  (expression_statement
+    (raw_string_literal
+      content: (raw_string_literal_content))))
 
 ================================================================================
 Character literals


### PR DESCRIPTION
This makes it possible to use language injection for this content.
Which is useful since this is something that raw string literals are often used for.

A query like the following could for example be used to provide sql highlighting when using sqlx:
```clojure
; extends
((macro_invocation
   macro: (scoped_identifier
            path: (identifier) @macropath (#eq? @macropath "sqlx")
            name: (identifier) @macroname)
   (token_tree
     (raw_string_literal
       content: (_) @injection.content)))
 (#set! injection.language "sql")
)
``` 

__Note: I have not ran `tree-sitter-cli generate` in order to keep the commit smaller for review purposes.__

If you are interested in merging this but want me to change or add something (or run that code generation) then I am willing to do so.