### PR TITLE
feat: support CStr literals

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: vigoux/tree-sitter-fuzz-action@v1
         with:
-          language: bash
+          language: rust
           external-scanner: src/scanner.c
           time: 60

--- a/grammar.js
+++ b/grammar.js
@@ -1445,7 +1445,7 @@ module.exports = grammar({
     )),
 
     string_literal: $ => seq(
-      alias(/b?"/, '"'),
+      alias(/[bc]?"/, '"'),
       repeat(choice(
         $.escape_sequence,
         $._string_content,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2397,50 +2397,54 @@
       }
     },
     "where_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "where"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "where_predicate"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "where_predicate"
-                  }
-                ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "where"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "where_predicate"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "where_predicate"
+                    }
+                  ]
+                }
               }
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "where_predicate": {
       "type": "SEQ",
@@ -6162,8 +6166,20 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "SYMBOL",
-                          "name": "_expression"
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "attribute_item"
+                              }
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "_expression"
+                            }
+                          ]
                         },
                         {
                           "type": "REPEAT",
@@ -6175,8 +6191,20 @@
                                 "value": ","
                               },
                               {
-                                "type": "SYMBOL",
-                                "name": "_expression"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT",
+                                    "content": {
+                                      "type": "SYMBOL",
+                                      "name": "attribute_item"
+                                    }
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "_expression"
+                                  }
+                                ]
                               }
                             ]
                           }
@@ -6933,7 +6961,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "loop_label"
+                  "name": "label"
                 },
                 {
                   "type": "STRING",
@@ -6979,7 +7007,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "loop_label"
+                  "name": "label"
                 },
                 {
                   "type": "STRING",
@@ -7017,7 +7045,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "loop_label"
+                  "name": "label"
                 },
                 {
                   "type": "STRING",
@@ -7246,7 +7274,7 @@
         }
       ]
     },
-    "loop_label": {
+    "label": {
       "type": "SEQ",
       "members": [
         {
@@ -7274,7 +7302,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "loop_label"
+                "name": "label"
               },
               {
                 "type": "BLANK"
@@ -7311,7 +7339,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "loop_label"
+                "name": "label"
               },
               {
                 "type": "BLANK"
@@ -7446,6 +7474,27 @@
     "block": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "label"
+                },
+                {
+                  "type": "STRING",
+                  "value": ":"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
         {
           "type": "STRING",
           "value": "{"
@@ -8334,7 +8383,7 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "b?\""
+            "value": "[bc]?\""
           },
           "named": false,
           "value": "\""
@@ -8724,6 +8773,9 @@
     [
       "type_parameters",
       "for_lifetimes"
+    ],
+    [
+      "array_expression"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -869,6 +869,10 @@
         {
           "type": "expression_statement",
           "named": true
+        },
+        {
+          "type": "label",
+          "named": true
         }
       ]
     }
@@ -929,7 +933,7 @@
           "named": true
         },
         {
-          "type": "loop_label",
+          "type": "label",
           "named": true
         }
       ]
@@ -1418,7 +1422,7 @@
       "required": false,
       "types": [
         {
-          "type": "loop_label",
+          "type": "label",
           "named": true
         }
       ]
@@ -1909,7 +1913,7 @@
       "required": false,
       "types": [
         {
-          "type": "loop_label",
+          "type": "label",
           "named": true
         }
       ]
@@ -2447,6 +2451,21 @@
     }
   },
   {
+    "type": "label",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "let_chain",
     "named": true,
     "fields": {},
@@ -2582,22 +2601,7 @@
       "required": false,
       "types": [
         {
-          "type": "loop_label",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "loop_label",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
+          "type": "label",
           "named": true
         }
       ]
@@ -4731,7 +4735,7 @@
       "required": false,
       "types": [
         {
-          "type": "loop_label",
+          "type": "label",
           "named": true
         }
       ]

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,4 +1,4 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 #include <wctype.h>
 
 enum TokenType {
@@ -43,10 +43,10 @@ bool tree_sitter_rust_external_scanner_scan(void *payload, TSLexer *lexer,
 
   if (
     valid_symbols[RAW_STRING_LITERAL] &&
-    (lexer->lookahead == 'r' || lexer->lookahead == 'b')
+    (lexer->lookahead == 'r' || lexer->lookahead == 'b' || lexer->lookahead == 'c')
   ) {
     lexer->result_symbol = RAW_STRING_LITERAL;
-    if (lexer->lookahead == 'b') advance(lexer);
+    if (lexer->lookahead == 'b' || lexer->lookahead == 'c') advance(lexer);
     if (lexer->lookahead != 'r') return false;
     advance(lexer);
 

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -73,6 +73,7 @@ String literals
 
 "";
 "abc";
+c"foo";
 b"foo\nbar";
 "foo\
     bar";
@@ -84,6 +85,8 @@ b"foo\nbar";
 --------------------------------------------------------------------------------
 
 (source_file
+  (expression_statement
+    (string_literal))
   (expression_statement
     (string_literal))
   (expression_statement
@@ -138,6 +141,21 @@ Raw byte string literals
 
 br#"abc"#;
 br##"abc"##;
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (raw_string_literal))
+  (expression_statement
+    (raw_string_literal)))
+
+================================================================================
+Raw C string literals
+================================================================================
+
+cr#"abc"#;
+cr##"abc"##;
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Given that FCP vote is started on https://github.com/rust-lang/rust/pull/117472 and it’s likely to hit stable soon-ish, I think it’s time to support `c"foo"` and `cr#"foo"#` in tree-sitter-rust.

This PR contains a lot of irrelevant changes in auto-generated files which I’m not sure how to handle. Is there a standardized environment to regenerate those?