### PR TITLE
refactor!: use last-wins precedence for queries

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,8 +1,18 @@
+; Identifiers
+
+(type_identifier) @type
+(primitive_type) @type.builtin
+(field_identifier) @property
+
 ; Identifier conventions
 
 ; Assume all-caps names are constants
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z\\d_]+$'"))
+
+; Assume uppercase names are enum constructors
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
 
 ; Assume that uppercase names in paths are types
 ((scoped_identifier
@@ -19,10 +29,6 @@
   path: (scoped_identifier
     name: (identifier) @type))
  (#match? @type "^[A-Z]"))
-
-; Assume other uppercase names are enum constructors
-((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
 
 ; Assume all qualified names in struct patterns are enum constructors. (They're
 ; either that, or struct names; highlighting both as constructors seems to be
@@ -60,12 +66,6 @@
 
 (function_item (identifier) @function)
 (function_signature_item (identifier) @function)
-
-; Other identifiers
-
-(type_identifier) @type
-(primitive_type) @type.builtin
-(field_identifier) @property
 
 (line_comment) @comment
 (block_comment) @comment


### PR DESCRIPTION
Refs:
https://github.com/tree-sitter/tree-sitter/pull/2412
https://github.com/tree-sitter/tree-sitter/pull/2947

Max and I have agreed this is the way to go, and should be the default now after making it an opt-in flag for 7 months.

These queries aren't perfect (never were anyways), but they allow the tests upstream to pass and mostly work.