### PR TITLE
Expose doc comment contents

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8674,21 +8674,21 @@
               "type": "SEQ",
               "members": [
                 {
+                  "type": "SYMBOL",
+                  "name": "_line_doc_comment_marker"
+                },
+                {
                   "type": "FIELD",
                   "name": "doc",
                   "content": {
                     "type": "ALIAS",
                     "content": {
                       "type": "SYMBOL",
-                      "name": "_line_doc_comment"
+                      "name": "_line_doc_content"
                     },
                     "named": true,
                     "value": "doc_comment"
                   }
-                },
-                {
-                  "type": "PATTERN",
-                  "value": ".*"
                 }
               ]
             },
@@ -8707,7 +8707,7 @@
         }
       ]
     },
-    "_line_doc_comment": {
+    "_line_doc_comment_marker": {
       "type": "CHOICE",
       "members": [
         {
@@ -8717,10 +8717,10 @@
             "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
-              "name": "_outer_line_doc_comment"
+              "name": "_outer_line_doc_comment_marker"
             },
             "named": true,
-            "value": "outer_doc_comment"
+            "value": "outer_doc_comment_marker"
           }
         },
         {
@@ -8730,15 +8730,15 @@
             "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
-              "name": "_inner_line_doc_comment"
+              "name": "_inner_line_doc_comment_marker"
             },
             "named": true,
-            "value": "inner_doc_comment"
+            "value": "inner_doc_comment_marker"
           }
         }
       ]
     },
-    "_inner_line_doc_comment": {
+    "_inner_line_doc_comment_marker": {
       "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "PREC",
@@ -8749,14 +8749,14 @@
         }
       }
     },
-    "_outer_line_doc_comment": {
+    "_outer_line_doc_comment_marker": {
       "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "PREC",
         "value": 2,
         "content": {
-          "type": "PATTERN",
-          "value": "\\/[^\\/\\r\\n]?"
+          "type": "STRING",
+          "value": "/"
         }
       }
     },
@@ -8771,17 +8771,43 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "doc",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_block_doc_comment"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_block_doc_comment_marker"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "FIELD",
+                          "name": "doc",
+                          "content": {
+                            "type": "ALIAS",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "_block_comment_content"
+                            },
+                            "named": true,
+                            "value": "doc_comment"
+                          }
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "named": true,
-                "value": "doc_comment"
-              }
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_comment_content"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -8794,22 +8820,9 @@
         }
       ]
     },
-    "_block_doc_comment": {
+    "_block_doc_comment_marker": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "FIELD",
-          "name": "inner",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_inner_block_doc_comment"
-            },
-            "named": true,
-            "value": "inner_doc_comment"
-          }
-        },
         {
           "type": "FIELD",
           "name": "outer",
@@ -8817,10 +8830,23 @@
             "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
-              "name": "_outer_block_doc_comment"
+              "name": "_outer_block_doc_comment_marker"
             },
             "named": true,
-            "value": "outer_doc_comment"
+            "value": "outer_doc_comment_marker"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "inner",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_inner_block_doc_comment_marker"
+            },
+            "named": true,
+            "value": "inner_doc_comment_marker"
           }
         }
       ]
@@ -9056,15 +9082,19 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_outer_block_doc_comment"
+      "name": "_outer_block_doc_comment_marker"
     },
     {
       "type": "SYMBOL",
-      "name": "_inner_block_doc_comment"
+      "name": "_inner_block_doc_comment_marker"
     },
     {
-      "type": "STRING",
-      "value": "*/"
+      "type": "SYMBOL",
+      "name": "_block_comment_content"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_line_doc_content"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -894,6 +894,26 @@
             "named": true
           }
         ]
+      },
+      "inner": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "inner_doc_comment_marker",
+            "named": true
+          }
+        ]
+      },
+      "outer": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "outer_doc_comment_marker",
+            "named": true
+          }
+        ]
       }
     }
   },
@@ -1465,32 +1485,6 @@
           "named": true
         }
       ]
-    }
-  },
-  {
-    "type": "doc_comment",
-    "named": true,
-    "fields": {
-      "inner": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "inner_doc_comment",
-            "named": true
-          }
-        ]
-      },
-      "outer": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "outer_doc_comment",
-            "named": true
-          }
-        ]
-      }
     }
   },
   {
@@ -2641,6 +2635,26 @@
         "types": [
           {
             "type": "doc_comment",
+            "named": true
+          }
+        ]
+      },
+      "inner": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "inner_doc_comment_marker",
+            "named": true
+          }
+        ]
+      },
+      "outer": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "outer_doc_comment_marker",
             "named": true
           }
         ]
@@ -5086,6 +5100,10 @@
     "named": false
   },
   {
+    "type": "doc_comment",
+    "named": true
+  },
+  {
     "type": "dyn",
     "named": false
   },
@@ -5150,7 +5168,7 @@
     "named": false
   },
   {
-    "type": "inner_doc_comment",
+    "type": "inner_doc_comment_marker",
     "named": true
   },
   {
@@ -5206,7 +5224,7 @@
     "named": true
   },
   {
-    "type": "outer_doc_comment",
+    "type": "outer_doc_comment_marker",
     "named": true
   },
   {

--- a/test/corpus/source_files.txt
+++ b/test/corpus/source_files.txt
@@ -20,11 +20,11 @@ Block comments
   (block_comment)
   (block_comment)
   (block_comment
-    doc: (doc_comment
-      outer: (outer_doc_comment)))
+    outer: (outer_doc_comment_marker)
+    doc: (doc_comment))
   (block_comment
-    doc: (doc_comment
-      inner: (inner_doc_comment)))
+    inner: (inner_doc_comment_marker)
+    doc: (doc_comment))
   (block_comment))
 
 ============================================
@@ -73,11 +73,11 @@ Line comments
 (source_file
   (line_comment)
   (line_comment
-    doc: (doc_comment
-      outer: (outer_doc_comment)))
+    outer: (outer_doc_comment_marker)
+    doc: (doc_comment))
   (line_comment
-    doc: (doc_comment
-      inner: (inner_doc_comment))))
+    inner: (inner_doc_comment_marker)
+    doc: (doc_comment)))
 
 ====================================
 Line doc comments
@@ -87,21 +87,25 @@ Line doc comments
 
 //   - Only a comment
 ///  - Outer line doc (exactly 3 slashes)
+///
 //// - Only a comment
 
 ---
 
 (source_file
   (line_comment
-    doc: (doc_comment
-      inner: (inner_doc_comment)))
+    inner: (inner_doc_comment_marker)
+    doc: (doc_comment))
   (line_comment
-    doc: (doc_comment
-      inner: (inner_doc_comment)))
+    inner: (inner_doc_comment_marker)
+    doc: (doc_comment))
   (line_comment)
   (line_comment
-    doc: (doc_comment
-      outer: (outer_doc_comment)))
+    outer: (outer_doc_comment_marker)
+    doc: (doc_comment))
+  (line_comment
+    outer: (outer_doc_comment_marker)
+    doc: (doc_comment))
   (line_comment))
 
 ====================================
@@ -119,15 +123,15 @@ Block doc comments
 
 (source_file
   (block_comment
-    (doc_comment
-      (inner_doc_comment)))
+    inner: (inner_doc_comment_marker)
+    doc: (doc_comment))
   (block_comment
-    (doc_comment
-      (inner_doc_comment)))
+    inner: (inner_doc_comment_marker)
+    doc: (doc_comment))
   (block_comment)
   (block_comment
-    (doc_comment
-      (outer_doc_comment)))
+    outer: (outer_doc_comment_marker)
+    doc: (doc_comment))
   (block_comment))
 
 =====================================
@@ -143,11 +147,11 @@ Nested doc block comments
 (source_file
   (block_comment)
   (block_comment
-    (doc_comment
-      (inner_doc_comment)))
+    inner: (inner_doc_comment_marker)
+    doc: (doc_comment))
   (block_comment
-    (doc_comment
-      (outer_doc_comment))))
+    outer: (outer_doc_comment_marker)
+    doc: (doc_comment)))
 
 ====================================
 Comments degenerate cases
@@ -170,20 +174,31 @@ let x; // <- immediate item after an empty line doc comment
 
 (source_file
   (line_comment
-    (doc_comment
-      (inner_doc_comment)))
+    (inner_doc_comment_marker)
+    (doc_comment))
   (block_comment
-    (doc_comment
-      (inner_doc_comment)))
+    (inner_doc_comment_marker))
   (line_comment)
   (line_comment
-    (doc_comment
-      (outer_doc_comment)))
+    (outer_doc_comment_marker)
+    (doc_comment))
   (let_declaration
     (identifier))
   (line_comment)
   (block_comment)
   (block_comment))
+
+================================================================================
+Line doc comment with no EOL
+================================================================================
+
+//! Doc comment
+--------------------------------------------------------------------------------
+
+(source_file
+  (line_comment
+    (inner_doc_comment_marker)
+    (doc_comment)))
 
 =====================================
 Greek letters in identifiers
@@ -195,5 +210,11 @@ const ψ_2 : Ψ = 1;
 ---
 
 (source_file
-  (const_item (identifier) (type_identifier) (integer_literal))
-  (const_item (identifier) (type_identifier) (integer_literal)))
+  (const_item
+    (identifier)
+    (type_identifier)
+    (integer_literal))
+  (const_item
+    (identifier)
+    (type_identifier)
+    (integer_literal)))


### PR DESCRIPTION
#195 parsed doc comments but it exposed the nodes for the doc comment markers (`!`/`/`) rather than the content of the comments. The comment content is useful for injecting markdown into the comments:

```scm
; injections.scm
([(line_comment !doc) (block_comment !doc)] @injection.content
 (#set! injection.language "comment"))

((doc_comment) @injection.content
 (#set! injection.language "markdown")
 (#set! injection.combined))
```

I've also changed the line doc comment slightly to fix an issue with the marker node (it unnecessarily consumed the character after the `///`) and to include the line's line-ending, which is useful to tree-sitter-markdown.

~cc @ProfDoof I've only made the change to line comments, I may need some help to make block comments have the same structure~

Block comment changes are included as well.