### PR TITLE
fix: allow brackets for macro definitions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -172,6 +172,7 @@ module.exports = grammar({
         )),
         choice(
           seq('(', rules, ')', ';'),
+          seq('[', rules, ']', ';'),
           seq('{', rules, '}'),
         ),
       );

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -240,6 +240,56 @@
               "members": [
                 {
                   "type": "STRING",
+                  "value": "["
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "macro_rule"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": ";"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "macro_rule"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "]"
+                },
+                {
+                  "type": "STRING",
+                  "value": ";"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
                   "value": "{"
                 },
                 {

--- a/test/corpus/macros.txt
+++ b/test/corpus/macros.txt
@@ -184,6 +184,10 @@ macro_rules! zero_or_one {
     };
 }
 
+macro_rules! empty [
+    () => {};
+];
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -254,4 +258,9 @@ macro_rules! zero_or_one {
             type: (fragment_specifier))))
       right: (token_tree
         (token_repetition
-          (metavariable))))))
+          (metavariable)))))
+  (macro_definition
+    name: (identifier)
+    (macro_rule
+      left: (token_tree_pattern)
+      right: (token_tree))))


### PR DESCRIPTION
I noticed brackets in macro definitions was missing, added with a test. See Rust reference page [here](https://doc.rust-lang.org/reference/macros-by-example.html). I ran the tests which passed.