### PR TITLE
Compiling on Windows fails due to invalid numeric argument /Wno-unused-parameter

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.flag("-Wno-unused-parameter");
+    c_config.flag_if_supported("-Wno-unused-parameter");
     c_config.std("c11").include(src_dir);
 
     let parser_path = src_dir.join("parser.c");


### PR DESCRIPTION
```
The following warnings were emitted during compilation:     

warning: tree-sitter-rust@0.21.0: cl : Command line error D8021 : invalid numeric argument '/Wno-unused-parameter'

error: failed to run custom build command for `tree-sitter-rust v0.21.0`

Caused by:
  process didn't exit successfully: `C:\Users\benja\Documents\Coding\Apps\CodeForge\src-tauri\target\debug\build\tree-sitter-rust-4bf300168c778a12\build-script-build` (exit code: 1)
  --- stderr


  error occurred: Command "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.37.32822\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-std:c11" "-I" "src" "-W4" "-Wno-unused-parameter" "-FoC:\\Users\\benja\\Documents\\Coding\\Apps\\CodeForge\\src-tauri\\target\\debug\\build\\tree-sitter-rust-b51e979015ad4c6a\\out\\2e40c9e35e9506f4-parser.o" "-c" "src\\parser.c" with args cl.exe did not execute successfully (status code exit code: 2).
  ```