### PR TITLE
add `comment` node that contains plain comments content

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1533,10 +1533,10 @@ module.exports = grammar({
       // - or just content for the comment
       choice(
         // A tricky edge case where what looks like a doc comment is not
-        seq(token.immediate(prec(2, /\/\//)), /.*/),
+        seq(token.immediate(prec(3, /\/\//)), field('comment', alias(/.*/, $.comment))),
         // A regular doc comment
         seq($._line_doc_comment_marker, field('doc', alias($._line_doc_content, $.doc_comment))),
-        token.immediate(prec(1, /.*/)),
+        field('comment', alias(token.immediate(prec(1, /.*/)), $.comment)),
       ),
     ),
 
@@ -1560,7 +1560,7 @@ module.exports = grammar({
             optional(field('doc', alias($._block_comment_content, $.doc_comment))),
           ),
           // Non-doc block comments
-          $._block_comment_content,
+          field('comment', alias($._block_comment_content, $.comment)),
         ),
       ),
       '*/',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8923,7 +8923,7 @@
                   "type": "IMMEDIATE_TOKEN",
                   "content": {
                     "type": "PREC",
-                    "value": 2,
+                    "value": 3,
                     "content": {
                       "type": "PATTERN",
                       "value": "\\/\\/"
@@ -8931,8 +8931,17 @@
                   }
                 },
                 {
-                  "type": "PATTERN",
-                  "value": ".*"
+                  "type": "FIELD",
+                  "name": "comment",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": ".*"
+                    },
+                    "named": true,
+                    "value": "comment"
+                  }
                 }
               ]
             },
@@ -8959,14 +8968,23 @@
               ]
             },
             {
-              "type": "IMMEDIATE_TOKEN",
+              "type": "FIELD",
+              "name": "comment",
               "content": {
-                "type": "PREC",
-                "value": 1,
+                "type": "ALIAS",
                 "content": {
-                  "type": "PATTERN",
-                  "value": ".*"
-                }
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 1,
+                    "content": {
+                      "type": "PATTERN",
+                      "value": ".*"
+                    }
+                  }
+                },
+                "named": true,
+                "value": "comment"
               }
             }
           ]
@@ -9070,8 +9088,17 @@
                   ]
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_block_comment_content"
+                  "type": "FIELD",
+                  "name": "comment",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_block_comment_content"
+                    },
+                    "named": true,
+                    "value": "comment"
+                  }
                 }
               ]
             },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -907,6 +907,16 @@
     "type": "block_comment",
     "named": true,
     "fields": {
+      "comment": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "comment",
+            "named": true
+          }
+        ]
+      },
       "doc": {
         "multiple": false,
         "required": false,
@@ -2619,6 +2629,16 @@
     "type": "line_comment",
     "named": true,
     "fields": {
+      "comment": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "comment",
+            "named": true
+          }
+        ]
+      },
       "doc": {
         "multiple": false,
         "required": false,
@@ -5125,6 +5145,10 @@
   },
   {
     "type": "char_literal",
+    "named": true
+  },
+  {
+    "type": "comment",
     "named": true
   },
   {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -335,7 +335,8 @@ pub unsafe extern "C" fn c_variadic_no_use(fmt: *const i8, mut ap: ...) -> i32 {
         (identifier)))
     (primitive_type)
     (block
-      (line_comment)
+      (line_comment
+        (comment))
       (call_expression
         (identifier)
         (arguments
@@ -345,7 +346,8 @@ pub unsafe extern "C" fn c_variadic_no_use(fmt: *const i8, mut ap: ...) -> i32 {
               (identifier)
               (field_identifier))
             (arguments))))
-      (line_comment))))
+      (line_comment
+        (comment)))))
 
 ================================================================================
 Use declarations
@@ -1318,7 +1320,8 @@ pub enum Error {
 --------------------------------------------------------------------------------
 
 (source_file
-  (line_comment)
+  (line_comment
+    (comment))
   (use_declaration
     (scoped_identifier
       (identifier)
@@ -1614,7 +1617,8 @@ impl Foo {
         (parameters)
         (primitive_type)
         (block
-          (line_comment)
+          (line_comment
+            (comment))
           (expression_statement
             (call_expression
               (field_expression

--- a/test/corpus/macros.txt
+++ b/test/corpus/macros.txt
@@ -154,8 +154,10 @@ ok! {
   (macro_invocation
     (identifier)
     (token_tree
-      (line_comment)
-      (block_comment))))
+      (line_comment
+        (comment))
+      (block_comment
+        (comment)))))
 
 ================================================================================
 Macro definition

--- a/test/corpus/source_files.txt
+++ b/test/corpus/source_files.txt
@@ -17,8 +17,10 @@ Block comments
 ----
 
 (source_file
-  (block_comment)
-  (block_comment)
+  (block_comment
+    comment: (comment))
+  (block_comment
+    comment: (comment))
   (block_comment
     outer: (outer_doc_comment_marker)
     doc: (doc_comment))
@@ -51,12 +53,18 @@ Nested block comments
 ----
 
 (source_file
-  (block_comment)
-  (line_comment)
-  (block_comment)
-  (line_comment)
-  (block_comment)
-  (line_comment))
+  (block_comment
+    (comment))
+  (line_comment
+    (comment))
+  (block_comment
+    (comment))
+  (line_comment
+    (comment))
+  (block_comment
+    (comment))
+  (line_comment
+    (comment)))
 
 ============================================
 Line comments
@@ -71,7 +79,8 @@ Line comments
 ----
 
 (source_file
-  (line_comment)
+  (line_comment
+    comment: (comment))
   (line_comment
     outer: (outer_doc_comment_marker)
     doc: (doc_comment))
@@ -99,14 +108,16 @@ Line doc comments
   (line_comment
     inner: (inner_doc_comment_marker)
     doc: (doc_comment))
-  (line_comment)
+  (line_comment
+    comment: (comment))
   (line_comment
     outer: (outer_doc_comment_marker)
     doc: (doc_comment))
   (line_comment
     outer: (outer_doc_comment_marker)
     doc: (doc_comment))
-  (line_comment))
+  (line_comment
+    comment: (comment)))
 
 ====================================
 Block doc comments
@@ -128,11 +139,13 @@ Block doc comments
   (block_comment
     inner: (inner_doc_comment_marker)
     doc: (doc_comment))
-  (block_comment)
+  (block_comment
+    comment: (comment))
   (block_comment
     outer: (outer_doc_comment_marker)
     doc: (doc_comment))
-  (block_comment))
+  (block_comment
+    comment: (comment)))
 
 =====================================
 Nested doc block comments
@@ -145,7 +158,8 @@ Nested doc block comments
 ----
 
 (source_file
-  (block_comment)
+  (block_comment
+    comment: (comment))
   (block_comment
     inner: (inner_doc_comment_marker)
     doc: (doc_comment))
@@ -178,15 +192,18 @@ let x; // <- immediate item after an empty line doc comment
     (doc_comment))
   (block_comment
     (inner_doc_comment_marker))
-  (line_comment)
+  (line_comment
+    (comment))
   (line_comment
     (outer_doc_comment_marker)
     (doc_comment))
   (let_declaration
     (identifier))
-  (line_comment)
+  (line_comment
+    (comment))
   (block_comment)
-  (block_comment))
+  (block_comment
+    (comment)))
 
 ================================================================================
 Line doc comment with no EOL


### PR DESCRIPTION
Hi 👋🏻,

I'm working on https://github.com/mrnossiom/lspelling that use TS to extract strings and identifiers from source code to spellcheck them. The grammar works fine to extract `doc_comments` content, string literals content.

This PR adds a `comment` field on `line_comment` and `block_comment` that contain a `comment` node with the comment content. It enables easy access to comment content without having to do node matching and strip comment markers based on the node type.

This change matches other parts of the grammar, like `string_content` or `doc_comment`.
Names for both the `node` and the `field` feel a bit too generic to me. Maybe node: `comment_content` and `content`?

I intend to propose such a change on other grammars as well. I was wondering if such a change would have a significant perf impact.