### PR TITLE
feat: support macros 2.0

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -136,6 +136,7 @@ module.exports = grammar({
     _declaration_statement: $ => choice(
       $.const_item,
       $.macro_invocation,
+      $.macro_rules,
       $.macro_definition,
       $.empty_statement,
       $.attribute_item,
@@ -159,7 +160,7 @@ module.exports = grammar({
 
     // Section - Macro definitions
 
-    macro_definition: $ => {
+    macro_rules: $ => {
       const rules = seq(
         repeat(seq($.macro_rule, ';')),
         optional($.macro_rule),
@@ -179,10 +180,42 @@ module.exports = grammar({
       );
     },
 
+    macro_definition: $ => {
+      const rules = seq(
+        repeat(seq($.macro_rule, ',')),
+        optional($.macro_rule),
+      );
+
+      return seq(
+        optional($.visibility_modifier),
+        'macro',
+        field('name', choice(
+          $.identifier,
+          $._reserved_identifier,
+        )),
+        choice(
+          seq($.macro_def_args, $.macro_def_body),
+          seq('{', rules, '}'),
+        ),
+      );
+    },
+
     macro_rule: $ => seq(
       field('left', $.token_tree_pattern),
       '=>',
       field('right', $.token_tree),
+    ),
+
+    macro_def_args: $ => seq(
+      '(',
+      field('left', repeat($._token_pattern)),
+      ')',
+    ),
+
+    macro_def_body: $ => seq(
+      '{',
+      field('right', repeat($._tokens)),
+      '}',
     ),
 
     _token_pattern: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -82,6 +82,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "macro_rules"
+        },
+        {
+          "type": "SYMBOL",
           "name": "macro_definition"
         },
         {
@@ -158,7 +162,7 @@
         }
       ]
     },
-    "macro_definition": {
+    "macro_rules": {
       "type": "SEQ",
       "members": [
         {
@@ -335,6 +339,108 @@
         }
       ]
     },
+    "macro_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "visibility_modifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "macro"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_reserved_identifier"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "macro_def_args"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "macro_def_body"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "macro_rule"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "macro_rule"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "macro_rule": {
       "type": "SEQ",
       "members": [
@@ -357,6 +463,54 @@
             "type": "SYMBOL",
             "name": "token_tree"
           }
+        }
+      ]
+    },
+    "macro_def_args": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "FIELD",
+          "name": "left",
+          "content": {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_token_pattern"
+            }
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "macro_def_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "right",
+          "content": {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_tokens"
+            }
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -60,6 +60,10 @@
         "named": true
       },
       {
+        "type": "macro_rules",
+        "named": true
+      },
+      {
         "type": "mod_item",
         "named": true
       },
@@ -2480,11 +2484,6 @@
     }
   },
   {
-    "type": "inner_doc_comment_marker",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "label",
     "named": true,
     "fields": {},
@@ -2678,6 +2677,690 @@
     }
   },
   {
+    "type": "macro_def_args",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "!",
+            "named": false
+          },
+          {
+            "type": "!=",
+            "named": false
+          },
+          {
+            "type": "#",
+            "named": false
+          },
+          {
+            "type": "%",
+            "named": false
+          },
+          {
+            "type": "%=",
+            "named": false
+          },
+          {
+            "type": "&",
+            "named": false
+          },
+          {
+            "type": "&&",
+            "named": false
+          },
+          {
+            "type": "&=",
+            "named": false
+          },
+          {
+            "type": "'",
+            "named": false
+          },
+          {
+            "type": "*",
+            "named": false
+          },
+          {
+            "type": "*=",
+            "named": false
+          },
+          {
+            "type": "+",
+            "named": false
+          },
+          {
+            "type": "+=",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "-",
+            "named": false
+          },
+          {
+            "type": "-=",
+            "named": false
+          },
+          {
+            "type": "->",
+            "named": false
+          },
+          {
+            "type": ".",
+            "named": false
+          },
+          {
+            "type": "..",
+            "named": false
+          },
+          {
+            "type": "...",
+            "named": false
+          },
+          {
+            "type": "..=",
+            "named": false
+          },
+          {
+            "type": "/",
+            "named": false
+          },
+          {
+            "type": "/=",
+            "named": false
+          },
+          {
+            "type": ":",
+            "named": false
+          },
+          {
+            "type": "::",
+            "named": false
+          },
+          {
+            "type": ";",
+            "named": false
+          },
+          {
+            "type": "<",
+            "named": false
+          },
+          {
+            "type": "<<",
+            "named": false
+          },
+          {
+            "type": "<<=",
+            "named": false
+          },
+          {
+            "type": "<=",
+            "named": false
+          },
+          {
+            "type": "=",
+            "named": false
+          },
+          {
+            "type": "==",
+            "named": false
+          },
+          {
+            "type": "=>",
+            "named": false
+          },
+          {
+            "type": ">",
+            "named": false
+          },
+          {
+            "type": ">=",
+            "named": false
+          },
+          {
+            "type": ">>",
+            "named": false
+          },
+          {
+            "type": ">>=",
+            "named": false
+          },
+          {
+            "type": "?",
+            "named": false
+          },
+          {
+            "type": "@",
+            "named": false
+          },
+          {
+            "type": "^",
+            "named": false
+          },
+          {
+            "type": "^=",
+            "named": false
+          },
+          {
+            "type": "_",
+            "named": false
+          },
+          {
+            "type": "_literal",
+            "named": true
+          },
+          {
+            "type": "as",
+            "named": false
+          },
+          {
+            "type": "async",
+            "named": false
+          },
+          {
+            "type": "await",
+            "named": false
+          },
+          {
+            "type": "break",
+            "named": false
+          },
+          {
+            "type": "const",
+            "named": false
+          },
+          {
+            "type": "continue",
+            "named": false
+          },
+          {
+            "type": "crate",
+            "named": true
+          },
+          {
+            "type": "default",
+            "named": false
+          },
+          {
+            "type": "enum",
+            "named": false
+          },
+          {
+            "type": "fn",
+            "named": false
+          },
+          {
+            "type": "for",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if",
+            "named": false
+          },
+          {
+            "type": "impl",
+            "named": false
+          },
+          {
+            "type": "let",
+            "named": false
+          },
+          {
+            "type": "loop",
+            "named": false
+          },
+          {
+            "type": "match",
+            "named": false
+          },
+          {
+            "type": "metavariable",
+            "named": true
+          },
+          {
+            "type": "mod",
+            "named": false
+          },
+          {
+            "type": "mutable_specifier",
+            "named": true
+          },
+          {
+            "type": "primitive_type",
+            "named": true
+          },
+          {
+            "type": "pub",
+            "named": false
+          },
+          {
+            "type": "return",
+            "named": false
+          },
+          {
+            "type": "self",
+            "named": true
+          },
+          {
+            "type": "static",
+            "named": false
+          },
+          {
+            "type": "struct",
+            "named": false
+          },
+          {
+            "type": "super",
+            "named": true
+          },
+          {
+            "type": "token_binding_pattern",
+            "named": true
+          },
+          {
+            "type": "token_repetition_pattern",
+            "named": true
+          },
+          {
+            "type": "token_tree_pattern",
+            "named": true
+          },
+          {
+            "type": "trait",
+            "named": false
+          },
+          {
+            "type": "type",
+            "named": false
+          },
+          {
+            "type": "union",
+            "named": false
+          },
+          {
+            "type": "unsafe",
+            "named": false
+          },
+          {
+            "type": "use",
+            "named": false
+          },
+          {
+            "type": "where",
+            "named": false
+          },
+          {
+            "type": "while",
+            "named": false
+          },
+          {
+            "type": "|",
+            "named": false
+          },
+          {
+            "type": "|=",
+            "named": false
+          },
+          {
+            "type": "||",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "macro_def_body",
+    "named": true,
+    "fields": {
+      "right": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "!",
+            "named": false
+          },
+          {
+            "type": "!=",
+            "named": false
+          },
+          {
+            "type": "#",
+            "named": false
+          },
+          {
+            "type": "%",
+            "named": false
+          },
+          {
+            "type": "%=",
+            "named": false
+          },
+          {
+            "type": "&",
+            "named": false
+          },
+          {
+            "type": "&&",
+            "named": false
+          },
+          {
+            "type": "&=",
+            "named": false
+          },
+          {
+            "type": "'",
+            "named": false
+          },
+          {
+            "type": "*",
+            "named": false
+          },
+          {
+            "type": "*=",
+            "named": false
+          },
+          {
+            "type": "+",
+            "named": false
+          },
+          {
+            "type": "+=",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "-",
+            "named": false
+          },
+          {
+            "type": "-=",
+            "named": false
+          },
+          {
+            "type": "->",
+            "named": false
+          },
+          {
+            "type": ".",
+            "named": false
+          },
+          {
+            "type": "..",
+            "named": false
+          },
+          {
+            "type": "...",
+            "named": false
+          },
+          {
+            "type": "..=",
+            "named": false
+          },
+          {
+            "type": "/",
+            "named": false
+          },
+          {
+            "type": "/=",
+            "named": false
+          },
+          {
+            "type": ":",
+            "named": false
+          },
+          {
+            "type": "::",
+            "named": false
+          },
+          {
+            "type": ";",
+            "named": false
+          },
+          {
+            "type": "<",
+            "named": false
+          },
+          {
+            "type": "<<",
+            "named": false
+          },
+          {
+            "type": "<<=",
+            "named": false
+          },
+          {
+            "type": "<=",
+            "named": false
+          },
+          {
+            "type": "=",
+            "named": false
+          },
+          {
+            "type": "==",
+            "named": false
+          },
+          {
+            "type": "=>",
+            "named": false
+          },
+          {
+            "type": ">",
+            "named": false
+          },
+          {
+            "type": ">=",
+            "named": false
+          },
+          {
+            "type": ">>",
+            "named": false
+          },
+          {
+            "type": ">>=",
+            "named": false
+          },
+          {
+            "type": "?",
+            "named": false
+          },
+          {
+            "type": "@",
+            "named": false
+          },
+          {
+            "type": "^",
+            "named": false
+          },
+          {
+            "type": "^=",
+            "named": false
+          },
+          {
+            "type": "_",
+            "named": false
+          },
+          {
+            "type": "_literal",
+            "named": true
+          },
+          {
+            "type": "as",
+            "named": false
+          },
+          {
+            "type": "async",
+            "named": false
+          },
+          {
+            "type": "await",
+            "named": false
+          },
+          {
+            "type": "break",
+            "named": false
+          },
+          {
+            "type": "const",
+            "named": false
+          },
+          {
+            "type": "continue",
+            "named": false
+          },
+          {
+            "type": "crate",
+            "named": true
+          },
+          {
+            "type": "default",
+            "named": false
+          },
+          {
+            "type": "enum",
+            "named": false
+          },
+          {
+            "type": "fn",
+            "named": false
+          },
+          {
+            "type": "for",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if",
+            "named": false
+          },
+          {
+            "type": "impl",
+            "named": false
+          },
+          {
+            "type": "let",
+            "named": false
+          },
+          {
+            "type": "loop",
+            "named": false
+          },
+          {
+            "type": "match",
+            "named": false
+          },
+          {
+            "type": "metavariable",
+            "named": true
+          },
+          {
+            "type": "mod",
+            "named": false
+          },
+          {
+            "type": "mutable_specifier",
+            "named": true
+          },
+          {
+            "type": "primitive_type",
+            "named": true
+          },
+          {
+            "type": "pub",
+            "named": false
+          },
+          {
+            "type": "return",
+            "named": false
+          },
+          {
+            "type": "self",
+            "named": true
+          },
+          {
+            "type": "static",
+            "named": false
+          },
+          {
+            "type": "struct",
+            "named": false
+          },
+          {
+            "type": "super",
+            "named": true
+          },
+          {
+            "type": "token_repetition",
+            "named": true
+          },
+          {
+            "type": "token_tree",
+            "named": true
+          },
+          {
+            "type": "trait",
+            "named": false
+          },
+          {
+            "type": "type",
+            "named": false
+          },
+          {
+            "type": "union",
+            "named": false
+          },
+          {
+            "type": "unsafe",
+            "named": false
+          },
+          {
+            "type": "use",
+            "named": false
+          },
+          {
+            "type": "where",
+            "named": false
+          },
+          {
+            "type": "while",
+            "named": false
+          },
+          {
+            "type": "|",
+            "named": false
+          },
+          {
+            "type": "|=",
+            "named": false
+          },
+          {
+            "type": "||",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "macro_definition",
     "named": true,
     "fields": {
@@ -2697,7 +3380,19 @@
       "required": false,
       "types": [
         {
+          "type": "macro_def_args",
+          "named": true
+        },
+        {
+          "type": "macro_def_body",
+          "named": true
+        },
+        {
           "type": "macro_rule",
+          "named": true
+        },
+        {
+          "type": "visibility_modifier",
           "named": true
         }
       ]
@@ -2757,6 +3452,32 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "macro_rules",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "macro_rule",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -3027,11 +3748,6 @@
         }
       ]
     }
-  },
-  {
-    "type": "outer_doc_comment_marker",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "parameter",
@@ -5212,6 +5928,10 @@
     "named": false
   },
   {
+    "type": "inner_doc_comment_marker",
+    "named": true
+  },
+  {
     "type": "integer_literal",
     "named": true
   },
@@ -5233,6 +5953,10 @@
   },
   {
     "type": "loop",
+    "named": false
+  },
+  {
+    "type": "macro",
     "named": false
   },
   {
@@ -5261,6 +5985,10 @@
   },
   {
     "type": "mutable_specifier",
+    "named": true
+  },
+  {
+    "type": "outer_doc_comment_marker",
     "named": true
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,7 +47,6 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
-  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {

--- a/test/corpus/macros.txt
+++ b/test/corpus/macros.txt
@@ -197,7 +197,7 @@ macro_rules! empty [
 --------------------------------------------------------------------------------
 
 (source_file
-  (macro_definition
+  (macro_rules
     name: (identifier)
     (macro_rule
       left: (token_tree_pattern)
@@ -206,14 +206,14 @@ macro_rules! empty [
         (token_tree
           (string_literal
             (string_content))))))
-  (macro_definition
+  (macro_rules
     name: (identifier)
     (macro_rule
       left: (token_tree_pattern)
       right: (token_tree
         (integer_literal)
         (integer_literal))))
-  (macro_definition
+  (macro_rules
     name: (identifier)
     (macro_rule
       left: (token_tree_pattern
@@ -239,7 +239,7 @@ macro_rules! empty [
           (string_literal
             (string_content))
           (metavariable)))))
-  (macro_definition
+  (macro_rules
     name: (identifier)
     (macro_rule
       left: (token_tree_pattern
@@ -257,7 +257,7 @@ macro_rules! empty [
           (token_repetition
             (metavariable)
             (metavariable))))))
-  (macro_definition
+  (macro_rules
     name: (identifier)
     (macro_rule
       left: (token_tree_pattern
@@ -268,8 +268,183 @@ macro_rules! empty [
       right: (token_tree
         (token_repetition
           (metavariable)))))
-  (macro_definition
+  (macro_rules
     name: (identifier)
     (macro_rule
       left: (token_tree_pattern)
       right: (token_tree))))
+
+================================================================================
+Macro definition 2.0
+================================================================================
+macro_rules! replace_expr_ {
+    ($_t:tt $sub:expr) => { $sub }
+}
+macro replace_expr($_t:tt $sub:expr) {
+    $sub
+}
+
+macro_rules! count_tts_ {
+    () => { 0 };
+    ($odd:tt $($a:tt $b:tt)*) => { (count_tts!($($a)*) << 1) | 1 };
+    ($($a:tt $even:tt)*) => { count_tts!($($a)*) << 1 };
+}
+macro count_tts {
+    () => { 0 },
+    ($odd:tt $($a:tt $b:tt)*) => { (count_tts!($($a)*) << 1) | 1 },
+    ($($a:tt $even:tt)*) => { count_tts!($($a)*) << 1 },
+}
+
+macro empty() {}
+--------------------------------------------------------------------------------
+(source_file
+ (macro_rules
+  (identifier)
+  (macro_rule
+   (token_tree_pattern
+    (token_binding_pattern
+     (metavariable)
+     (fragment_specifier))
+    (token_binding_pattern
+     (metavariable)
+     (fragment_specifier)))
+   (token_tree
+    (metavariable))))
+ (macro_definition
+  (identifier)
+  (macro_def_args
+   (token_binding_pattern
+    (metavariable)
+    (fragment_specifier))
+   (token_binding_pattern
+    (metavariable)
+    (fragment_specifier)))
+  (macro_def_body
+   (metavariable)))
+ (macro_rules
+  (identifier)
+  (macro_rule
+   (token_tree_pattern)
+   (token_tree
+    (integer_literal)))
+  (macro_rule
+   (token_tree_pattern
+    (token_binding_pattern
+     (metavariable)
+     (fragment_specifier))
+    (token_repetition_pattern
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))))
+   (token_tree
+    (token_tree
+     (identifier)
+     (token_tree
+      (token_repetition
+       (metavariable)))
+     (integer_literal))
+    (integer_literal)))
+  (macro_rule
+   (token_tree_pattern
+    (token_repetition_pattern
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))))
+   (token_tree
+    (identifier)
+    (token_tree
+     (token_repetition
+      (metavariable)))
+    (integer_literal))))
+ (macro_definition
+  (identifier)
+  (macro_rule
+   (token_tree_pattern)
+   (token_tree
+    (integer_literal)))
+  (macro_rule
+   (token_tree_pattern
+    (token_binding_pattern
+     (metavariable)
+     (fragment_specifier))
+    (token_repetition_pattern
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))))
+   (token_tree
+    (token_tree
+     (identifier)
+     (token_tree
+      (token_repetition
+       (metavariable)))
+     (integer_literal))
+    (integer_literal)))
+  (macro_rule
+   (token_tree_pattern
+    (token_repetition_pattern
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))
+     (token_binding_pattern
+      (metavariable)
+      (fragment_specifier))))
+   (token_tree
+    (identifier)
+    (token_tree
+     (token_repetition
+      (metavariable)))
+    (integer_literal))))
+  (macro_definition
+   (identifier)
+    (macro_def_args)
+     (macro_def_body)))
+
+================================================================================
+Namespaced Macro Calls
+================================================================================
+mod a {
+    pub macro foo() { bar() }
+    pub fn bar() { }
+}
+
+fn main() {
+    a::foo!();  // Expansion calls a::bar
+}
+--------------------------------------------------------------------------------
+(source_file
+ (mod_item
+  (identifier)
+  (declaration_list
+   (macro_definition
+    (visibility_modifier)
+    (identifier)
+    (macro_def_args)
+    (macro_def_body
+     (identifier)
+     (token_tree)))
+   (function_item
+    (visibility_modifier)
+    (identifier)
+    (parameters)
+    (block))))
+ (function_item
+  (identifier)
+  (parameters)
+  (block
+   (expression_statement
+    (macro_invocation
+     (scoped_identifier
+      (identifier)
+      (identifier))
+     (token_tree)))
+   (line_comment))))
+


### PR DESCRIPTION
fix #45

This PR rename the former `macro_definition` (`macro_rules!`) to `macro_rules`, and reuse `macro_definition` for the new `macro` syntax.

Tests are copied from the RFC: https://github.com/rust-lang/rfcs/blob/master/text/1584-macros.md.