### PR TITLE
Support `gen` block syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -239,9 +239,9 @@ module.exports = grammar({
       alias(choice(...primitiveTypes), $.primitive_type),
       prec.right(repeat1(choice(...TOKEN_TREE_NON_SPECIAL_PUNCTUATION))),
       '\'',
-      'as', 'async', 'await', 'break', 'const', 'continue', 'default', 'enum', 'fn', 'for', 'if', 'impl',
-      'let', 'loop', 'match', 'mod', 'pub', 'return', 'static', 'struct', 'trait', 'type',
-      'union', 'unsafe', 'use', 'where', 'while',
+      'as', 'async', 'await', 'break', 'const', 'continue', 'default', 'enum', 'fn', 'for', 'gen',
+      'if', 'impl', 'let', 'loop', 'match', 'mod', 'pub', 'return', 'static', 'struct', 'trait',
+      'type', 'union', 'unsafe', 'use', 'where', 'while',
     ),
 
     // Section - Declarations
@@ -931,6 +931,7 @@ module.exports = grammar({
     _expression_ending_with_block: $ => choice(
       $.unsafe_block,
       $.async_block,
+      $.gen_block,
       $.try_block,
       $.block,
       $.if_expression,
@@ -1307,6 +1308,12 @@ module.exports = grammar({
 
     async_block: $ => seq(
       'async',
+      optional('move'),
+      $.block,
+    ),
+
+    gen_block: $ => seq(
+      'gen',
       optional('move'),
       $.block,
     ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -110,6 +110,7 @@
 "extern" @keyword
 "fn" @keyword
 "for" @keyword
+"gen" @keyword
 "if" @keyword
 "impl" @keyword
 "in" @keyword

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1068,6 +1068,10 @@
         },
         {
           "type": "STRING",
+          "value": "gen"
+        },
+        {
+          "type": "STRING",
           "value": "if"
         },
         {
@@ -5246,6 +5250,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "gen_block"
+        },
+        {
+          "type": "SYMBOL",
           "name": "try_block"
         },
         {
@@ -7732,6 +7740,31 @@
         {
           "type": "STRING",
           "value": "async"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "move"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block"
+        }
+      ]
+    },
+    "gen_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "gen"
         },
         {
           "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -154,6 +154,10 @@
         "named": true
       },
       {
+        "type": "gen_block",
+        "named": true
+      },
+      {
         "type": "generic_function",
         "named": true
       },
@@ -1077,6 +1081,10 @@
           },
           {
             "type": "for_expression",
+            "named": true
+          },
+          {
+            "type": "gen_block",
             "named": true
           },
           {
@@ -2208,6 +2216,21 @@
         },
         {
           "type": "function_modifiers",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "gen_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block",
           "named": true
         }
       ]
@@ -5190,6 +5213,10 @@
   },
   {
     "type": "for",
+    "named": false
+  },
+  {
+    "type": "gen",
     "named": false
   },
   {

--- a/test/corpus/async.txt
+++ b/test/corpus/async.txt
@@ -99,3 +99,34 @@ try {}
   (expression_statement
     (try_block
       (block))))
+
+================================================================================
+Gen Block
+================================================================================
+
+gen {}
+gen { let x = 10; }
+gen { yield (); }
+gen move {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (gen_block
+      (block)))
+  (expression_statement
+    (gen_block
+      (block
+        (let_declaration
+          (identifier)
+          (integer_literal)))))
+  (expression_statement
+    (gen_block
+      (block
+        (expression_statement
+          (yield_expression
+            (unit_expression))))))
+  (expression_statement
+    (gen_block
+      (block))))


### PR DESCRIPTION
Add support for the `gen` block syntax, currently gated after `#![feature(gen_blocks)]` in nightly Rust.