### PR TITLE
feat: Support `&raw {const|mut} expr` syntax (take 2)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1018,7 +1018,10 @@ module.exports = grammar({
 
     reference_expression: $ => prec(PREC.unary, seq(
       '&',
-      optional($.mutable_specifier),
+      choice(
+        seq('raw', choice('const', $.mutable_specifier)),
+        optional($.mutable_specifier),
+      ),
       field('value', $._expression),
     )),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -121,6 +121,7 @@
 "mod" @keyword
 "move" @keyword
 "pub" @keyword
+"raw" @keyword
 "ref" @keyword
 "return" @keyword
 "static" @keyword

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5717,11 +5717,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "mutable_specifier"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "raw"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "const"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "mutable_specifier"
+                      }
+                    ]
+                  }
+                ]
               },
               {
-                "type": "BLANK"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "mutable_specifier"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               }
             ]
           },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5308,6 +5308,10 @@
     "named": false
   },
   {
+    "type": "raw",
+    "named": false
+  },
+  {
     "type": "ref",
     "named": false
   },

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -66,10 +66,21 @@ Reference expressions
 
 &a;
 &mut self.name;
+&raw const b;
+&raw mut self.age;
 
 --------------------------------------------------------------------------------
 
 (source_file
+  (expression_statement
+    (reference_expression
+      (identifier)))
+  (expression_statement
+    (reference_expression
+      (mutable_specifier)
+      (field_expression
+        (self)
+        (field_identifier))))
   (expression_statement
     (reference_expression
       (identifier)))


### PR DESCRIPTION
Add support for 1.82's `&raw {const|mut} expr` syntax.

Closes #239.