### PR TITLE
Attach outer attributes to the elements they annotate

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -137,7 +137,6 @@ module.exports = grammar({
       $.macro_invocation,
       $.macro_definition,
       $.empty_statement,
-      $.attribute_item,
       $.inner_attribute_item,
       $.mod_item,
       $.foreign_mod_item,
@@ -269,6 +268,7 @@ module.exports = grammar({
     ),
 
     mod_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'mod',
       field('name', $.identifier),
@@ -279,6 +279,7 @@ module.exports = grammar({
     ),
 
     foreign_mod_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       $.extern_modifier,
       choice(
@@ -294,6 +295,7 @@ module.exports = grammar({
     ),
 
     struct_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'struct',
       field('name', $._type_identifier),
@@ -313,6 +315,7 @@ module.exports = grammar({
     ),
 
     union_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'union',
       field('name', $._type_identifier),
@@ -322,6 +325,7 @@ module.exports = grammar({
     ),
 
     enum_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'enum',
       field('name', $._type_identifier),
@@ -376,6 +380,7 @@ module.exports = grammar({
     ),
 
     extern_crate_declaration: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'extern',
       $.crate,
@@ -388,6 +393,7 @@ module.exports = grammar({
     ),
 
     const_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'const',
       field('name', $.identifier),
@@ -403,6 +409,7 @@ module.exports = grammar({
     ),
 
     static_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'static',
 
@@ -421,6 +428,7 @@ module.exports = grammar({
     ),
 
     type_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'type',
       field('name', $._type_identifier),
@@ -433,6 +441,7 @@ module.exports = grammar({
     ),
 
     function_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       optional($.function_modifiers),
       'fn',
@@ -445,6 +454,7 @@ module.exports = grammar({
     ),
 
     function_signature_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       optional($.function_modifiers),
       'fn',
@@ -489,6 +499,7 @@ module.exports = grammar({
     ),
 
     impl_item: $ => seq(
+      repeat($.attribute_item),
       optional('unsafe'),
       'impl',
       field('type_parameters', optional($.type_parameters)),
@@ -507,6 +518,7 @@ module.exports = grammar({
     ),
 
     trait_item: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       optional('unsafe'),
       'trait',
@@ -518,6 +530,7 @@ module.exports = grammar({
     ),
 
     associated_type: $ => seq(
+      repeat($.attribute_item),
       'type',
       field('name', $._type_identifier),
       field('type_parameters', optional($.type_parameters)),
@@ -598,6 +611,7 @@ module.exports = grammar({
     )),
 
     let_declaration: $ => seq(
+      repeat($.attribute_item),
       'let',
       optional($.mutable_specifier),
       field('pattern', $._pattern),
@@ -617,6 +631,7 @@ module.exports = grammar({
     ),
 
     use_declaration: $ => seq(
+      repeat($.attribute_item),
       optional($.visibility_modifier),
       'use',
       field('argument', $._use_clause),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -91,10 +91,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "attribute_item"
-        },
-        {
-          "type": "SYMBOL",
           "name": "inner_attribute_item"
         },
         {
@@ -1242,6 +1238,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -1287,6 +1290,13 @@
     "foreign_mod_item": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
@@ -1345,6 +1355,13 @@
     "struct_item": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
@@ -1454,6 +1471,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -1518,6 +1542,13 @@
     "enum_item": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
@@ -1974,6 +2005,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -2035,6 +2073,13 @@
     "const_item": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
@@ -2105,6 +2150,13 @@
     "static_item": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
@@ -2200,6 +2252,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -2284,6 +2343,13 @@
     "function_item": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
@@ -2403,6 +2469,13 @@
     "function_signature_item": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [
@@ -2746,6 +2819,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -2870,6 +2950,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -2962,6 +3049,13 @@
     "associated_type": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "STRING",
           "value": "type"
@@ -3400,6 +3494,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
+        {
           "type": "STRING",
           "value": "let"
         },
@@ -3507,6 +3608,13 @@
     "use_declaration": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_item"
+          }
+        },
         {
           "type": "CHOICE",
           "members": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8,10 +8,6 @@
         "named": true
       },
       {
-        "type": "attribute_item",
-        "named": true
-      },
-      {
         "type": "const_item",
         "named": true
       },
@@ -658,9 +654,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "where_clause",
           "named": true
@@ -1393,9 +1393,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "visibility_modifier",
           "named": true
@@ -1577,6 +1581,10 @@
       "required": false,
       "types": [
         {
+          "type": "attribute_item",
+          "named": true
+        },
+        {
           "type": "visibility_modifier",
           "named": true
         },
@@ -1700,6 +1708,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "crate",
           "named": true
@@ -1995,6 +2007,10 @@
       "required": true,
       "types": [
         {
+          "type": "attribute_item",
+          "named": true
+        },
+        {
           "type": "extern_modifier",
           "named": true
         },
@@ -2073,6 +2089,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "function_modifiers",
           "named": true
@@ -2156,6 +2176,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "function_modifiers",
           "named": true
@@ -2496,9 +2520,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "where_clause",
           "named": true
@@ -2647,9 +2675,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "mutable_specifier",
           "named": true
@@ -2983,9 +3015,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "visibility_modifier",
           "named": true
@@ -3732,6 +3768,10 @@
       "required": false,
       "types": [
         {
+          "type": "attribute_item",
+          "named": true
+        },
+        {
           "type": "mutable_specifier",
           "named": true
         },
@@ -3838,6 +3878,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "visibility_modifier",
           "named": true
@@ -4194,6 +4238,10 @@
       "required": false,
       "types": [
         {
+          "type": "attribute_item",
+          "named": true
+        },
+        {
           "type": "visibility_modifier",
           "named": true
         },
@@ -4458,6 +4506,10 @@
       "required": false,
       "types": [
         {
+          "type": "attribute_item",
+          "named": true
+        },
+        {
           "type": "visibility_modifier",
           "named": true
         },
@@ -4589,6 +4641,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "visibility_modifier",
           "named": true
@@ -4742,9 +4798,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_item",
+          "named": true
+        },
         {
           "type": "visibility_modifier",
           "named": true

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1234,41 +1234,41 @@ mod macos_only {}
 
 #![allow(clippy::useless_transmute)]
 
-#[clippy::cyclomatic_complexity = "100"]
+#![clippy::cyclomatic_complexity = "100"]
 
 --------------------------------------------------------------------------------
 
 (source_file
-  (attribute_item
-    (attribute
-      (identifier)))
   (function_item
+    (attribute_item
+      (attribute
+        (identifier)))
     name: (identifier)
     parameters: (parameters)
     body: (block))
-  (attribute_item
-    (attribute
-      (identifier)
-      arguments: (token_tree
-        (identifier))))
   (struct_item
-    name: (type_identifier))
-  (attribute_item
-    (attribute
-      (identifier)
-      arguments: (token_tree
+    (attribute_item
+      (attribute
         (identifier)
-        (identifier))))
+        arguments: (token_tree
+          (identifier))))
+    name: (type_identifier))
   (struct_item
-    name: (type_identifier))
-  (attribute_item
-    (attribute
-      (identifier)
-      arguments: (token_tree
+    (attribute_item
+      (attribute
         (identifier)
-        (string_literal
-          (string_content)))))
+        arguments: (token_tree
+          (identifier)
+          (identifier))))
+    name: (type_identifier))
   (mod_item
+    (attribute_item
+      (attribute
+        (identifier)
+        arguments: (token_tree
+          (identifier)
+          (string_literal
+            (string_content)))))
     name: (identifier)
     body: (declaration_list))
   (inner_attribute_item
@@ -1277,7 +1277,7 @@ mod macos_only {}
       arguments: (token_tree
         (identifier)
         (identifier))))
-  (attribute_item
+  (inner_attribute_item
     (attribute
       (scoped_identifier
         path: (identifier)
@@ -1358,25 +1358,25 @@ fn baz() {}
 --------------------------------------------------------------------------------
 
 (source_file
-  (attribute_item
-    (attribute
-      (identifier)
-      (macro_invocation
-        (identifier)
-        (token_tree
-          (string_literal
-            (string_content))))))
   (function_item
+    (attribute_item
+      (attribute
+        (identifier)
+        (macro_invocation
+          (identifier)
+          (token_tree
+            (string_literal
+              (string_content))))))
     (identifier)
     (parameters)
     (block))
-  (attribute_item
-    (attribute
-      (identifier)
-      (scoped_identifier
-        (identifier)
-        (identifier))))
   (function_item
+    (attribute_item
+      (attribute
+        (identifier)
+        (scoped_identifier
+          (identifier)
+          (identifier))))
     (identifier)
     (parameters)
     (block)))
@@ -1447,13 +1447,13 @@ pub enum Error {
     (scoped_identifier
       (identifier)
       (identifier)))
-  (attribute_item
-    (attribute
-      (identifier)
-      (token_tree
-        (identifier)
-        (identifier))))
   (enum_item
+    (attribute_item
+      (attribute
+        (identifier)
+        (token_tree
+          (identifier)
+          (identifier))))
     (visibility_modifier)
     (type_identifier)
     (enum_variant_list


### PR DESCRIPTION
Fixes #244.

I reviewed which syntax elements outer attributes can be applied to: https://doc.rust-lang.org/reference/attributes.html.
I am not sure about `let_item`: I couldn't find the corresponding item declaration in this document. Perhaps it's something that has been added recently and this document hasn't been updated yet (as the preamble states). It would be good if someone with a better knowledge of the language could confirm that. In doubt, I think the safe way is to allow them.