### PR TITLE
parse use bounds (precise capture syntax)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -832,8 +832,25 @@ module.exports = grammar({
     bounded_type: $ => prec.left(-1, choice(
       seq($.lifetime, '+', $._type),
       seq($._type, '+', $._type),
-      seq($._type, '+', $.lifetime),
+      seq($._type, '+', choice(
+        $.lifetime,
+        $.use_bounds,
+      )),
     )),
+
+    use_bounds: $ => seq(
+      'use',
+      token(prec(1, '<')),
+      sepBy(
+        ',',
+        choice(
+          $.lifetime,
+          $._type_identifier,
+        ),
+      ),
+      optional(','),
+      '>',
+    ),
 
     type_arguments: $ => seq(
       token(prec(1, '<')),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4700,13 +4700,109 @@
                 "value": "+"
               },
               {
-                "type": "SYMBOL",
-                "name": "lifetime"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "lifetime"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "use_bounds"
+                  }
+                ]
               }
             ]
           }
         ]
       }
+    },
+    "use_bounds": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "use"
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "STRING",
+              "value": "<"
+            }
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "lifetime"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_type_identifier"
+                    }
+                  ]
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "lifetime"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_type_identifier"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
     },
     "type_arguments": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -967,6 +967,10 @@
         {
           "type": "lifetime",
           "named": true
+        },
+        {
+          "type": "use_bounds",
+          "named": true
         }
       ]
     }
@@ -4626,6 +4630,25 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "use_bounds",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "lifetime",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -267,6 +267,64 @@ fn triples(a: impl B) -> impl Iterator<Item=(usize)> {
     (block)))
 
 ================================================================================
+Functions with precise capture syntax
+================================================================================
+
+fn capture<T>(&self) -> impl Iterator<Item = usize> + use<'_, T> {
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_item
+    (identifier)
+    (type_parameters
+      (type_parameter
+      (type_identifier)))
+    (parameters
+      (self_parameter
+        (self)))
+    (bounded_type
+      (abstract_type
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_binding
+              (type_identifier)
+              (primitive_type)))))
+        (use_bounds
+          (lifetime
+            (identifier))
+          (type_identifier)))
+    (block)))
+
+================================================================================
+Functions with empty precise capture syntax
+================================================================================
+
+fn capture(&self) -> impl Iterator<Item = usize> + use<> {
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_item
+    (identifier)
+    (parameters
+      (self_parameter
+        (self)))
+    (bounded_type
+      (abstract_type
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_binding
+              (type_identifier)
+              (primitive_type)))))
+        (use_bounds))
+    (block)))
+
+================================================================================
 Diverging functions
 ================================================================================
 


### PR DESCRIPTION
```rs
fn capture(&self) -> impl Iterator<Item = usize> + use<'_> {}
```

currently tree-sitter-rust says that the `use` capture bound is a `generic_type` `type_identifier`, but after this it is a `use_bounds` `use`.

announced [here](https://blog.rust-lang.org/2024/09/05/impl-trait-capture-rules.html#impl-traits-can-include-a-use-bound-to-specify-precisely-which-generic-types-and-lifetimes-they-use), documented [here](https://doc.rust-lang.org/std/keyword.use.html#precise-capturing) and specified [here](https://doc.rust-lang.org/reference/types/impl-trait.html#precise-capturing) and [here](https://doc.rust-lang.org/reference/trait-bounds.html#trait-and-lifetime-bounds).