### PR TITLE
parse turbofish patterns

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1341,6 +1341,7 @@ module.exports = grammar({
       alias(choice(...primitiveTypes), $.identifier),
       $.identifier,
       $.scoped_identifier,
+      $.generic_pattern,
       $.tuple_pattern,
       $.tuple_struct_pattern,
       $.struct_pattern,
@@ -1356,6 +1357,15 @@ module.exports = grammar({
       $.const_block,
       $.macro_invocation,
       '_',
+    ),
+
+    generic_pattern: $ => seq(
+      choice(
+        $.identifier,
+        $.scoped_identifier,
+      ),
+      '::',
+      field('type_arguments', $.type_arguments),
     ),
 
     tuple_pattern: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7972,6 +7972,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "generic_pattern"
+        },
+        {
+          "type": "SYMBOL",
           "name": "tuple_pattern"
         },
         {
@@ -8029,6 +8033,36 @@
         {
           "type": "STRING",
           "value": "_"
+        }
+      ]
+    },
+    "generic_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "scoped_identifier"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "::"
+        },
+        {
+          "type": "FIELD",
+          "name": "type_arguments",
+          "content": {
+            "type": "SYMBOL",
+            "name": "type_arguments"
+          }
         }
       ]
     },
@@ -9465,5 +9499,6 @@
     "_literal_pattern",
     "_declaration_statement",
     "_pattern"
-  ]
+  ],
+  "reserved": {}
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -340,6 +340,10 @@
         "named": true
       },
       {
+        "type": "generic_pattern",
+        "named": true
+      },
+      {
         "type": "identifier",
         "named": true
       },
@@ -2268,6 +2272,36 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "generic_pattern",
+    "named": true,
+    "fields": {
+      "type_arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_arguments",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "scoped_identifier",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,12 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata TSLanguageMetadata;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +32,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +86,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +106,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +122,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +142,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -520,3 +520,30 @@ fn foo(x: i32) {
             (match_arm
               pattern: (match_pattern)
               value: (block))))))))
+
+================================================================================
+Pattern with turbofish
+================================================================================
+
+match y {
+    None::<T> => 17,
+    _ => 42,
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (match_expression
+      (identifier)
+      (match_block
+        (match_arm
+          (match_pattern
+            (generic_pattern
+              (identifier)
+              (type_arguments
+                (type_identifier))))
+          (integer_literal))
+        (match_arm
+          (match_pattern)
+          (integer_literal))))))


### PR DESCRIPTION
follow-up on parts of #229.

i made my own list of rustc tests that could be parsed by rustc, but couldn't be parsed with tree-sitter. with this change, here is the difference in that list:

<details>
<summary>diff</summary>

```diff
--- .tmp/list.txt	2025-02-27 14:52:48.714795961 +0100
+++ .tmp/list.txt.turbofish-patterns	2025-02-27 15:05:53.773283293 +0100
@@ -51,11 +51,6 @@
 tests/ui/async-await/pin-ergonomics/sugar.rs
 tests/ui/async-await/return-type-notation/supertrait-bound.rs
 tests/ui/attributes/issue-115264-pat-field.rs
-tests/ui/binding/match-bot.rs
-tests/ui/binding/match-join.rs
-tests/ui/binding/nested-matchs.rs
-tests/ui/binding/use-uninit-match.rs
-tests/ui/binding/use-uninit-match2.rs
 tests/ui/borrowck/alias-liveness/higher-ranked.rs
 tests/ui/borrowck/alias-liveness/rtn-static.rs
 tests/ui/closures/binder/late-bound-in-body.rs
@@ -197,7 +192,6 @@
 tests/ui/inline-const/pat-unsafe.rs
 tests/ui/issues/issue-22471.rs
 tests/ui/issues/issue-26186.rs
-tests/ui/issues/issue-34751.rs
 tests/ui/issues/issue-36116.rs
 tests/ui/issues/issue-37051.rs
 tests/ui/issues/issue-37733.rs
@@ -226,7 +220,6 @@
 tests/ui/macros/try-macro.rs
 tests/ui/macros/type-macros-hlist.rs
 tests/ui/macros/user-defined-macro-rules.rs
-tests/ui/match/match-bot-panic.rs
 tests/ui/match/postfix-match/no-unused-parens.rs
 tests/ui/match/postfix-match/pf-match-chain.rs
 tests/ui/nll/assign-while-to-immutable.rs
@@ -240,7 +233,6 @@
 tests/ui/parser/trait-plusequal-splitting.rs
 tests/ui/parser/unsafe-foreign-mod.rs
 tests/ui/pattern/issue-22546.rs
-tests/ui/pattern/size-and-align.rs
 tests/ui/pattern/usefulness/integer-ranges/issue-117648-overlapping_range_endpoints-false-positive.rs
 tests/ui/privacy/decl-macro-infinite-global-import-cycle-ice-64784.rs
 tests/ui/raw-ref-op/amp-raw-without-mut-const-is-a-normal-borrow.rs
@@ -268,7 +260,6 @@
 tests/ui/specialization/transmute-specialization.rs
 tests/ui/static/static-extern-type.rs
 tests/ui/structs-enums/numeric-fields.rs
-tests/ui/structs-enums/simple-match-generic-tag.rs
 tests/ui/structs-enums/struct-aliases.rs
 tests/ui/structs/default-field-values/use-normalized-ty-for-default-struct-value.rs
 tests/ui/traits/alias/basic.rs
```

</details>

i am not entirely sure when it is appropriate to do a `field` in tree-sitter, but i decided to put the `type_arguments` in a `field` like the `generic_type_with_turbofish` does, but not wrap the identifier in it, like all of the other patterns do.