### PR TITLE
parse default const parameters

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -566,6 +566,19 @@ module.exports = grammar({
       field('name', $.identifier),
       ':',
       field('type', $._type),
+      optional(
+        seq(
+          '=',
+          field('value',
+            choice(
+              $.block,
+              $.identifier,
+              $._literal,
+              $.negative_literal,
+            ),
+          ),
+        ),
+      ),
     ),
 
     constrained_type_parameter: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -107,7 +107,6 @@ module.exports = grammar({
     [$.scoped_identifier, $.scoped_type_identifier],
     [$.parameters, $._pattern],
     [$.parameters, $.tuple_struct_pattern],
-    [$.type_parameters, $.for_lifetimes],
     [$.array_expression],
     [$.visibility_modifier],
     [$.visibility_modifier, $.scoped_identifier, $.scoped_type_identifier],
@@ -549,11 +548,8 @@ module.exports = grammar({
       sepBy1(',', seq(
         repeat($.attribute_item),
         choice(
-          $.lifetime,
           $.metavariable,
-          $._type_identifier,
-          $.constrained_type_parameter,
-          $.optional_type_parameter,
+          $.type_parameter,
           $.const_parameter,
         ),
       )),
@@ -581,19 +577,16 @@ module.exports = grammar({
       ),
     ),
 
-    constrained_type_parameter: $ => seq(
-      field('left', choice($.lifetime, $._type_identifier)),
-      field('bounds', $.trait_bounds),
-    ),
-
-    optional_type_parameter: $ => seq(
-      field('name', choice(
-        $._type_identifier,
-        $.constrained_type_parameter,
-      )),
-      '=',
-      field('default_type', $._type),
-    ),
+    type_parameter: $ => prec(1, seq(
+      field('name', choice($.lifetime, $._type_identifier)),
+      optional(field('bounds', $.trait_bounds)),
+      optional(
+        seq(
+          '=',
+          field('default_type', $._type),
+        ),
+      ),
+    )),
 
     let_declaration: $ => seq(
       'let',

--- a/grammar.js
+++ b/grammar.js
@@ -550,6 +550,7 @@ module.exports = grammar({
         choice(
           $.metavariable,
           $.type_parameter,
+          $.lifetime_parameter,
           $.const_parameter,
         ),
       )),
@@ -578,7 +579,7 @@ module.exports = grammar({
     ),
 
     type_parameter: $ => prec(1, seq(
-      field('name', choice($.lifetime, $._type_identifier)),
+      field('name', $._type_identifier),
       optional(field('bounds', $.trait_bounds)),
       optional(
         seq(
@@ -586,6 +587,11 @@ module.exports = grammar({
           field('default_type', $._type),
         ),
       ),
+    )),
+
+    lifetime_parameter: $ => prec(1, seq(
+      field('name', $.lifetime),
+      optional(field('bounds', $.trait_bounds)),
     )),
 
     let_declaration: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3125,23 +3125,15 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "lifetime"
-                      },
-                      {
-                        "type": "SYMBOL",
                         "name": "metavariable"
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "_type_identifier"
+                        "name": "type_parameter"
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "constrained_type_parameter"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "optional_type_parameter"
+                        "name": "lifetime_parameter"
                       },
                       {
                         "type": "SYMBOL",
@@ -3175,23 +3167,15 @@
                           "members": [
                             {
                               "type": "SYMBOL",
-                              "name": "lifetime"
-                            },
-                            {
-                              "type": "SYMBOL",
                               "name": "metavariable"
                             },
                             {
                               "type": "SYMBOL",
-                              "name": "_type_identifier"
+                              "name": "type_parameter"
                             },
                             {
                               "type": "SYMBOL",
-                              "name": "constrained_type_parameter"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "optional_type_parameter"
+                              "name": "lifetime_parameter"
                             },
                             {
                               "type": "SYMBOL",
@@ -3251,72 +3235,141 @@
             "type": "SYMBOL",
             "name": "_type"
           }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "FIELD",
+                  "name": "value",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "block"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_literal"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "negative_literal"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
-    "constrained_type_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "left",
-          "content": {
+    "type_parameter": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_type_identifier"
+            }
+          },
+          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "lifetime"
+                "type": "FIELD",
+                "name": "bounds",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "trait_bounds"
+                }
               },
               {
-                "type": "SYMBOL",
-                "name": "_type_identifier"
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "default_type",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_type"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
               }
             ]
           }
-        },
-        {
-          "type": "FIELD",
-          "name": "bounds",
-          "content": {
-            "type": "SYMBOL",
-            "name": "trait_bounds"
-          }
-        }
-      ]
+        ]
+      }
     },
-    "optional_type_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
+    "lifetime_parameter": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "lifetime"
+            }
+          },
+          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_type_identifier"
+                "type": "FIELD",
+                "name": "bounds",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "trait_bounds"
+                }
               },
               {
-                "type": "SYMBOL",
-                "name": "constrained_type_parameter"
+                "type": "BLANK"
               }
             ]
           }
-        },
-        {
-          "type": "STRING",
-          "value": "="
-        },
-        {
-          "type": "FIELD",
-          "name": "default_type",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_type"
-          }
-        }
-      ]
+        ]
+      }
     },
     "let_declaration": {
       "type": "SEQ",
@@ -9422,10 +9475,6 @@
     [
       "parameters",
       "tuple_struct_pattern"
-    ],
-    [
-      "type_parameters",
-      "for_lifetimes"
     ],
     [
       "array_expression"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1418,33 +1418,25 @@
             "named": true
           }
         ]
-      }
-    }
-  },
-  {
-    "type": "constrained_type_parameter",
-    "named": true,
-    "fields": {
-      "bounds": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "trait_bounds",
-            "named": true
-          }
-        ]
       },
-      "left": {
+      "value": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
-            "type": "lifetime",
+            "type": "_literal",
             "named": true
           },
           {
-            "type": "type_identifier",
+            "type": "block",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "negative_literal",
             "named": true
           }
         ]
@@ -2673,6 +2665,32 @@
     }
   },
   {
+    "type": "lifetime_parameter",
+    "named": true,
+    "fields": {
+      "bounds": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "trait_bounds",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "lifetime",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "line_comment",
     "named": true,
     "fields": {
@@ -3009,36 +3027,6 @@
     "type": "never_type",
     "named": true,
     "fields": {}
-  },
-  {
-    "type": "optional_type_parameter",
-    "named": true,
-    "fields": {
-      "default_type": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_type",
-            "named": true
-          }
-        ]
-      },
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "constrained_type_parameter",
-            "named": true
-          },
-          {
-            "type": "type_identifier",
-            "named": true
-          }
-        ]
-      }
-    }
   },
   {
     "type": "or_pattern",
@@ -4438,6 +4426,42 @@
     }
   },
   {
+    "type": "type_parameter",
+    "named": true,
+    "fields": {
+      "bounds": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "trait_bounds",
+            "named": true
+          }
+        ]
+      },
+      "default_type": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_type",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "type_parameters",
     "named": true,
     "fields": {},
@@ -4454,11 +4478,7 @@
           "named": true
         },
         {
-          "type": "constrained_type_parameter",
-          "named": true
-        },
-        {
-          "type": "lifetime",
+          "type": "lifetime_parameter",
           "named": true
         },
         {
@@ -4466,11 +4486,7 @@
           "named": true
         },
         {
-          "type": "optional_type_parameter",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
+          "type": "type_parameter",
           "named": true
         }
       ]

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -2413,3 +2413,29 @@ where
             (type_arguments
               (type_identifier))))))
     (block)))
+
+================================================================================
+Const generics with default
+================================================================================
+
+pub struct Loaf<T: Sized, const N: usize = 1>([T; N]);
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (struct_item
+    (visibility_modifier)
+    (type_identifier)
+    (type_parameters
+      (constrained_type_parameter
+        (type_identifier)
+        (trait_bounds
+          (type_identifier)))
+      (const_parameter
+        (identifier)
+        (primitive_type)
+        (integer_literal)))
+    (ordered_field_declaration_list
+      (array_type
+        (type_identifier)
+        (identifier)))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -211,8 +211,9 @@ fn foo(bar: impl for<'a> Baz<Quux<'a>>) {}
         pattern: (identifier)
         type: (abstract_type
           (type_parameters
-            (lifetime
-              (identifier)))
+            (type_parameter
+              name: (lifetime
+                (identifier))))
           trait: (generic_type
             type: (type_identifier)
             type_arguments: (type_arguments
@@ -715,21 +716,25 @@ struct E<#[attr] T> {}
   (struct_item
     name: (type_identifier)
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     body: (field_declaration_list))
   (struct_item
     name: (type_identifier)
     type_parameters: (type_parameters
-      (lifetime
-        (identifier))
-      (lifetime
-        (identifier)))
+      (type_parameter
+        name: (lifetime
+          (identifier)))
+      (type_parameter
+        name: (lifetime
+          (identifier))))
     body: (field_declaration_list))
   (struct_item
     name: (type_identifier)
     type_parameters: (type_parameters
-      (lifetime
-        (identifier)))
+      (type_parameter
+        name: (lifetime
+          (identifier))))
     body: (field_declaration_list))
   (struct_item
     name: (type_identifier)
@@ -744,7 +749,8 @@ struct E<#[attr] T> {}
       (attribute_item
         (attribute
           (identifier)))
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     body: (field_declaration_list)))
 
 ================================================================================
@@ -775,7 +781,8 @@ pub enum Node<T: Item> {
     (visibility_modifier)
     (type_identifier)
     (type_parameters
-      (type_identifier))
+      (type_parameter
+        (type_identifier)))
     (enum_variant_list
       (enum_variant
         (identifier))
@@ -787,7 +794,7 @@ pub enum Node<T: Item> {
     (visibility_modifier)
     (type_identifier)
     (type_parameters
-      (constrained_type_parameter
+      (type_parameter
         (type_identifier)
         (trait_bounds
           (type_identifier))))
@@ -858,8 +865,8 @@ pub fn uninit_array<const LEN: usize>() -> [Self; LEN] {}
     (visibility_modifier)
     name: (identifier)
     type_parameters: (type_parameters
-      (constrained_type_parameter
-        left: (type_identifier)
+      (type_parameter
+        name: (type_identifier)
         bounds: (trait_bounds
           (generic_type
             type: (type_identifier)
@@ -1055,7 +1062,8 @@ type LazyResolve = impl (FnOnce() -> Capture) + Send + Sync + UnwindSafe;
   (type_item
     (type_identifier)
     (type_parameters
-      (type_identifier))
+      (type_parameter
+        (type_identifier)))
     (generic_type
       (type_identifier)
       (type_arguments
@@ -1496,8 +1504,9 @@ impl ConvertTo<i64> for i32 {
 (source_file
   (impl_item
     type_parameters: (type_parameters
-      (lifetime
-        (identifier)))
+      (type_parameter
+        name: (lifetime
+          (identifier))))
     trait: (scoped_type_identifier
       path: (identifier)
       name: (type_identifier))
@@ -1568,7 +1577,7 @@ impl<K: Debug + Ord> Display for OccupiedError<K>;
 (source_file
   (impl_item
     (type_parameters
-      (constrained_type_parameter
+      (type_parameter
         (type_identifier)
         (trait_bounds
           (type_identifier)
@@ -1580,7 +1589,7 @@ impl<K: Debug + Ord> Display for OccupiedError<K>;
         (type_identifier))))
   (impl_item
     (type_parameters
-      (constrained_type_parameter
+      (type_parameter
         (type_identifier)
         (trait_bounds
           (type_identifier)
@@ -1672,7 +1681,7 @@ trait Add<RHS=Self> {
   (trait_item
     (type_identifier)
     (type_parameters
-      (optional_type_parameter
+      (type_parameter
         (type_identifier)
         (type_identifier)))
     (declaration_list
@@ -1705,7 +1714,7 @@ fn univariant(this: &impl ?Sized, that: &(impl LayoutCalculator + ?Sized)) {}
   (trait_item
     (type_identifier)
     (type_parameters
-      (constrained_type_parameter
+      (type_parameter
         (type_identifier)
         (trait_bounds
           (removed_trait_bound
@@ -1742,7 +1751,7 @@ impl<T: AstDeref<Target: HasNodeId>> HasNodeId for T {}
 (source_file
   (impl_item
     (type_parameters
-      (constrained_type_parameter
+      (type_parameter
         (type_identifier)
         (trait_bounds
           (generic_type
@@ -1865,9 +1874,11 @@ where
       (associated_type
         (type_identifier)
         (type_parameters
-          (lifetime
-            (identifier))
-          (type_identifier))
+          (type_parameter
+            (lifetime
+              (identifier)))
+          (type_parameter
+            (type_identifier)))
         (trait_bounds
           (generic_type
             (type_identifier)
@@ -1884,9 +1895,11 @@ where
       (type_item
         (type_identifier)
         (type_parameters
-          (lifetime
-            (identifier))
-          (type_identifier))
+          (type_parameter
+            (lifetime
+              (identifier)))
+          (type_parameter
+            (type_identifier)))
         (generic_type
           (type_identifier)
           (type_arguments
@@ -1896,7 +1909,7 @@ where
   (function_item
     (identifier)
     (type_parameters
-      (constrained_type_parameter
+      (type_parameter
         (type_identifier)
         (trait_bounds
           (generic_type
@@ -1914,7 +1927,8 @@ where
   (function_item
     (identifier)
     (type_parameters
-      (type_identifier))
+      (type_parameter
+        (type_identifier)))
     (parameters)
     (where_clause
       (where_predicate
@@ -1949,8 +1963,9 @@ type FnObject<'b> = dyn for<'a> FnLike<&'a isize, &'a isize> + 'b;
     (trait_bounds
       (higher_ranked_trait_bound
         (type_parameters
-          (lifetime
-            (identifier)))
+          (type_parameter
+            (lifetime
+              (identifier))))
         (generic_type
           (type_identifier)
           (type_arguments
@@ -1962,14 +1977,16 @@ type FnObject<'b> = dyn for<'a> FnLike<&'a isize, &'a isize> + 'b;
   (type_item
     (type_identifier)
     (type_parameters
-      (lifetime
-        (identifier)))
+      (type_parameter
+        (lifetime
+          (identifier))))
     (bounded_type
       (dynamic_type
         (higher_ranked_trait_bound
           (type_parameters
-            (lifetime
-              (identifier)))
+            (type_parameter
+              (lifetime
+                (identifier))))
           (generic_type
             (type_identifier)
             (type_arguments
@@ -2101,7 +2118,8 @@ impl<A> Default for B<A> where *mut A: C + D {}
   (function_item
     name: (identifier)
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     parameters: (parameters
       (self_parameter
         (self))
@@ -2126,10 +2144,11 @@ impl<A> Default for B<A> where *mut A: C + D {}
         (boolean_literal))))
   (impl_item
     type_parameters: (type_parameters
-      (lifetime
-        (identifier))
-      (constrained_type_parameter
-        left: (type_identifier)
+      (type_parameter
+        name: (lifetime
+          (identifier)))
+      (type_parameter
+        name: (type_identifier)
         bounds: (trait_bounds
           (lifetime
             (identifier))
@@ -2150,7 +2169,8 @@ impl<A> Default for B<A> where *mut A: C + D {}
     body: (declaration_list))
   (impl_item
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     trait: (type_identifier)
     type: (generic_type
       type: (type_identifier)
@@ -2178,9 +2198,11 @@ impl<A> Default for B<A> where *mut A: C + D {}
     body: (declaration_list))
   (impl_item
     type_parameters: (type_parameters
-      (lifetime
-        (identifier))
-      (type_identifier))
+      (type_parameter
+        name: (lifetime
+          (identifier)))
+      (type_parameter
+        name: (type_identifier)))
     type: (type_identifier)
     (where_clause
       (where_predicate
@@ -2193,7 +2215,8 @@ impl<A> Default for B<A> where *mut A: C + D {}
     body: (declaration_list))
   (impl_item
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     trait: (type_identifier)
     type: (generic_type
       type: (type_identifier)
@@ -2210,7 +2233,8 @@ impl<A> Default for B<A> where *mut A: C + D {}
     body: (declaration_list))
   (impl_item
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     trait: (type_identifier)
     type: (generic_type
       type: (type_identifier)
@@ -2220,8 +2244,9 @@ impl<A> Default for B<A> where *mut A: C + D {}
       (where_predicate
         left: (higher_ranked_trait_bound
           type_parameters: (type_parameters
-            (lifetime
-              (identifier)))
+            (type_parameter
+              name: (lifetime
+                (identifier))))
           type: (generic_type
             type: (type_identifier)
             type_arguments: (type_arguments
@@ -2237,7 +2262,8 @@ impl<A> Default for B<A> where *mut A: C + D {}
     (visibility_modifier)
     name: (type_identifier)
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     (where_clause
       (where_predicate
         left: (type_identifier)
@@ -2247,7 +2273,8 @@ impl<A> Default for B<A> where *mut A: C + D {}
   (function_item
     name: (identifier)
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     parameters: (parameters)
     (where_clause
       (where_predicate
@@ -2268,7 +2295,8 @@ impl<A> Default for B<A> where *mut A: C + D {}
     body: (block))
   (impl_item
     type_parameters: (type_parameters
-      (type_identifier))
+      (type_parameter
+        name: (type_identifier)))
     trait: (type_identifier)
     type: (generic_type
       type: (type_identifier)
@@ -2397,7 +2425,8 @@ where
   (function_item
     (identifier)
     (type_parameters
-      (type_identifier))
+      (type_parameter
+        (type_identifier)))
     (parameters
       (parameter
         (identifier)
@@ -2427,7 +2456,7 @@ pub struct Loaf<T: Sized, const N: usize = 1>([T; N]);
     (visibility_modifier)
     (type_identifier)
     (type_parameters
-      (constrained_type_parameter
+      (type_parameter
         (type_identifier)
         (trait_bounds
           (type_identifier)))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -211,7 +211,7 @@ fn foo(bar: impl for<'a> Baz<Quux<'a>>) {}
         pattern: (identifier)
         type: (abstract_type
           (type_parameters
-            (type_parameter
+            (lifetime_parameter
               name: (lifetime
                 (identifier))))
           trait: (generic_type
@@ -722,17 +722,17 @@ struct E<#[attr] T> {}
   (struct_item
     name: (type_identifier)
     type_parameters: (type_parameters
-      (type_parameter
+      (lifetime_parameter
         name: (lifetime
           (identifier)))
-      (type_parameter
+      (lifetime_parameter
         name: (lifetime
           (identifier))))
     body: (field_declaration_list))
   (struct_item
     name: (type_identifier)
     type_parameters: (type_parameters
-      (type_parameter
+      (lifetime_parameter
         name: (lifetime
           (identifier))))
     body: (field_declaration_list))
@@ -1504,7 +1504,7 @@ impl ConvertTo<i64> for i32 {
 (source_file
   (impl_item
     type_parameters: (type_parameters
-      (type_parameter
+      (lifetime_parameter
         name: (lifetime
           (identifier))))
     trait: (scoped_type_identifier
@@ -1874,7 +1874,7 @@ where
       (associated_type
         (type_identifier)
         (type_parameters
-          (type_parameter
+          (lifetime_parameter
             (lifetime
               (identifier)))
           (type_parameter
@@ -1895,7 +1895,7 @@ where
       (type_item
         (type_identifier)
         (type_parameters
-          (type_parameter
+          (lifetime_parameter
             (lifetime
               (identifier)))
           (type_parameter
@@ -1963,7 +1963,7 @@ type FnObject<'b> = dyn for<'a> FnLike<&'a isize, &'a isize> + 'b;
     (trait_bounds
       (higher_ranked_trait_bound
         (type_parameters
-          (type_parameter
+          (lifetime_parameter
             (lifetime
               (identifier))))
         (generic_type
@@ -1977,14 +1977,14 @@ type FnObject<'b> = dyn for<'a> FnLike<&'a isize, &'a isize> + 'b;
   (type_item
     (type_identifier)
     (type_parameters
-      (type_parameter
+      (lifetime_parameter
         (lifetime
           (identifier))))
     (bounded_type
       (dynamic_type
         (higher_ranked_trait_bound
           (type_parameters
-            (type_parameter
+            (lifetime_parameter
               (lifetime
                 (identifier))))
           (generic_type
@@ -2144,7 +2144,7 @@ impl<A> Default for B<A> where *mut A: C + D {}
         (boolean_literal))))
   (impl_item
     type_parameters: (type_parameters
-      (type_parameter
+      (lifetime_parameter
         name: (lifetime
           (identifier)))
       (type_parameter
@@ -2198,7 +2198,7 @@ impl<A> Default for B<A> where *mut A: C + D {}
     body: (declaration_list))
   (impl_item
     type_parameters: (type_parameters
-      (type_parameter
+      (lifetime_parameter
         name: (lifetime
           (identifier)))
       (type_parameter
@@ -2244,7 +2244,7 @@ impl<A> Default for B<A> where *mut A: C + D {}
       (where_predicate
         left: (higher_ranked_trait_bound
           type_parameters: (type_parameters
-            (type_parameter
+            (lifetime_parameter
               name: (lifetime
                 (identifier))))
           type: (generic_type


### PR DESCRIPTION
fixes #228.

parse const parameter default assignments. specified [in the reference](https://doc.rust-lang.org/reference/items/generics.html#generic-parameters) it takes blocks, identifiers and literals (with optional minus).

also fixes some more of the mismatches from #229:

<details>
<summary>diff</summary>

```diff
--- .tmp/list.txt	2025-02-27 14:52:48.714795961 +0100
+++ .tmp/list.txt.default-const-params	2025-02-27 20:22:50.306213116 +0100
@@ -67,21 +67,12 @@
 tests/ui/coherence/coherence-overlap-negative-impls.rs
 tests/ui/const-generics/arg-in-pat-3.rs
 tests/ui/const-generics/const_trait_fn-issue-88433.rs
-tests/ui/const-generics/defaults/const-default.rs
 tests/ui/const-generics/defaults/const-param-as-default-value.rs
-tests/ui/const-generics/defaults/default-annotation.rs
-tests/ui/const-generics/defaults/repr-c-issue-82792.rs
 tests/ui/const-generics/defaults/rp_impl_trait.rs
 tests/ui/const-generics/defaults/trait_objects.rs
-tests/ui/const-generics/defaults/type-default-const-param-name.rs
-tests/ui/const-generics/generic_arg_infer/dont-use-defaults.rs
 tests/ui/const-generics/generic_const_exprs/drop_impl.rs
-tests/ui/const-generics/generic_const_exprs/inline-const-in-const-generic-defaults.rs
 tests/ui/const-generics/generic_const_exprs/issue-90847.rs
-tests/ui/const-generics/generic_const_exprs/unused-complex-default-expr.rs
 tests/ui/const-generics/issues/issue-88119.rs
-tests/ui/const-generics/min_const_generics/default_trait_param.rs
-tests/ui/const-generics/min_const_generics/type_and_const_defaults.rs
 tests/ui/consts/const-eval/issue-55541.rs
 tests/ui/consts/const-labeled-break.rs
 tests/ui/consts/trait_specialization.rs
@@ -136,8 +127,6 @@
 tests/ui/delegation/self-coercion.rs
 tests/ui/delegation/target-expr-pass.rs
 tests/ui/derives/derive-hygiene.rs
-tests/ui/derives/derive-macro-const-default.rs
-tests/ui/deriving/coerce-pointee-bounds-issue-127647.rs
 tests/ui/destructuring-assignment/struct_destructure.rs
 tests/ui/drop/dynamic-drop.rs
 tests/ui/dyn-compatibility/assoc_const_bounds.rs
```

</details>