### PR TITLE
add tuple_type to possible dynamic types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -912,6 +912,7 @@ module.exports = grammar({
         $.scoped_type_identifier,
         $.generic_type,
         $.function_type,
+        $.tuple_type,
       )),
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5167,6 +5167,10 @@
               {
                 "type": "SYMBOL",
                 "name": "function_type"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "tuple_type"
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1506,6 +1506,10 @@
             "named": true
           },
           {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
             "type": "type_identifier",
             "named": true
           }

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1682,6 +1682,35 @@ impl !Send for Foo {}
     (declaration_list)))
 
 ================================================================================
+Impl dyn with parentheses
+================================================================================
+
+pub unsafe trait Trait {}
+
+unsafe impl Trait for dyn (::std::any::Any) + Send { }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (trait_item
+    (visibility_modifier)
+    (type_identifier)
+    (declaration_list))
+  (impl_item
+    (type_identifier)
+    (bounded_type
+      (dynamic_type
+        (tuple_type
+          (scoped_type_identifier
+            (scoped_identifier
+              (scoped_identifier
+                (identifier))
+              (identifier))
+          (type_identifier))))
+      (type_identifier))
+    (declaration_list)))
+
+================================================================================
 Trait impl signature
 ================================================================================
 


### PR DESCRIPTION
fixes #227.

not sure if there's more that could be a dyn type but i couldn't think of anything else

diff for #229:

<details>
<summary>diff</summary>

```diff
--- .tmp/list.txt	2025-02-28 16:16:12.002933806 +0100
+++ .tmp/list.txt.impl-for-dyn-tuple-type	2025-02-28 22:40:03.716281612 +0100
@@ -169,7 +169,6 @@
 tests/ui/impl-trait/equality-rpass.rs
 tests/ui/implied-bounds/dyn-erasure-no-tait.rs
 tests/ui/implied-bounds/dyn-erasure-tait.rs
-tests/ui/imports/extern-crate-used.rs
 tests/ui/imports/import-glob-crate.rs
 tests/ui/imports/local-modularized-tricky-pass-2.rs
 tests/ui/inline-const/const-match-pat-inference.rs
@@ -183,7 +182,6 @@
 tests/ui/issues/issue-43692.rs
 tests/ui/issues/issue-49632.rs
 tests/ui/issues/issue-50187.rs
-tests/ui/issues/issue-50761.rs
 tests/ui/issues/issue-61475.rs
 tests/ui/lifetimes/elided-lifetime-in-param-pat.rs
 tests/ui/lint/dead-code/anon-const-in-pat.rs
@@ -297,7 +295,6 @@
 tests/ui/traits/const-traits/trait-where-clause-self-referential.rs
 tests/ui/traits/const-traits/predicate-entailment-passes.rs
 tests/ui/traits/dyn-trait.rs
-tests/ui/traits/impl-2.rs
 tests/ui/traits/issue-22110.rs
 tests/ui/traits/issue-56488.rs
 tests/ui/traits/issue-59029-2.rs
@@ -305,7 +302,6 @@
 tests/ui/traits/negative-bounds/supertrait.rs
 tests/ui/traits/next-solver/canonical/effect-var.rs
 tests/ui/traits/non_lifetime_binders/disqualifying-object-candidates.rs
-tests/ui/traits/object/issue-33140-traitobject-crate.rs
 tests/ui/traits/object/lifetime-first.rs
 tests/ui/trivial-bounds/issue-73021-impossible-inline.rs
 tests/ui/trivial-bounds/trivial-bounds-inconsistent.rs
```

</details>