### PR TITLE
parse impl types (abstract types) where the lifetime comes first

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -832,13 +832,10 @@ module.exports = grammar({
       field('type_arguments', $.type_arguments),
     ),
 
-    bounded_type: $ => prec.left(-1, choice(
-      seq($.lifetime, '+', $._type),
-      seq($._type, '+', $._type),
-      seq($._type, '+', choice(
-        $.lifetime,
-        $.use_bounds,
-      )),
+    bounded_type: $ => prec.left(-1, seq(
+      choice($.lifetime, $._type, $.use_bounds),
+      '+',
+      choice($.lifetime, $._type, $.use_bounds),
     )),
 
     use_bounds: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -896,14 +896,15 @@ module.exports = grammar({
     abstract_type: $ => seq(
       'impl',
       optional(seq('for', $.type_parameters)),
-      field('trait', choice(
+      field('trait', prec(1, choice(
         $._type_identifier,
         $.scoped_type_identifier,
         $.removed_trait_bound,
         $.generic_type,
         $.function_type,
         $.tuple_type,
-      )),
+        $.bounded_type,
+      ))),
     ),
 
     dynamic_type: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4685,65 +4685,43 @@
       "type": "PREC_LEFT",
       "value": -1,
       "content": {
-        "type": "CHOICE",
+        "type": "SEQ",
         "members": [
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
                 "type": "SYMBOL",
                 "name": "lifetime"
               },
               {
-                "type": "STRING",
-                "value": "+"
+                "type": "SYMBOL",
+                "name": "_type"
               },
               {
                 "type": "SYMBOL",
-                "name": "_type"
+                "name": "use_bounds"
               }
             ]
           },
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_type"
-              },
-              {
-                "type": "STRING",
-                "value": "+"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_type"
-              }
-            ]
+            "type": "STRING",
+            "value": "+"
           },
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
+              {
+                "type": "SYMBOL",
+                "name": "lifetime"
+              },
               {
                 "type": "SYMBOL",
                 "name": "_type"
               },
               {
-                "type": "STRING",
-                "value": "+"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "lifetime"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "use_bounds"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "use_bounds"
               }
             ]
           }
@@ -5118,33 +5096,41 @@
           "type": "FIELD",
           "name": "trait",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_type_identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "scoped_type_identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "removed_trait_bound"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "generic_type"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "function_type"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "tuple_type"
-              }
-            ]
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_type_identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "scoped_type_identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "removed_trait_bound"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "generic_type"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "function_type"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tuple_type"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "bounded_type"
+                }
+              ]
+            }
           }
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -480,6 +480,10 @@
         "required": true,
         "types": [
           {
+            "type": "bounded_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -267,6 +267,31 @@ fn triples(a: impl B) -> impl Iterator<Item=(usize)> {
     (block)))
 
 ================================================================================
+Impl with lifetimes first
+================================================================================
+
+fn foo<'a>(x: impl 'a + Clone) {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_item
+    (identifier)
+    (type_parameters
+      (lifetime_parameter
+        (lifetime
+          (identifier))))
+    (parameters
+      (parameter
+        (identifier)
+        (abstract_type
+          (bounded_type
+            (lifetime
+              (identifier))
+            (type_identifier)))))
+      (block)))
+
+================================================================================
 Functions with precise capture syntax
 ================================================================================
 


### PR DESCRIPTION
fixes: #234. i have two notes for this:

one: i had to use a `prec(1, ` to resolve conflicts with `_type`. i could have also just used a `_type` instead of the `prec(1, choice(`, but that would have allowed syntax like `impl *const u8` and `impl impl dyn Trait`, which i don't think should be possible.

<details>
<summary>the conflict</summary>

```txt
Error when generating parser

Caused by:
    Unresolved conflict for symbol sequence:
    
      '<'  'impl'  identifier  •  '+'  …
    
    Possible interpretations:
    
      1:  '<'  'impl'  (_type  identifier)  •  '+'  …
      2:  '<'  (abstract_type  'impl'  identifier)  •  '+'  …
    
    Possible resolutions:
    
      1:  Specify a higher precedence in `_type` than in the other rules.
      2:  Specify a higher precedence in `abstract_type` than in the other rules.
      3:  Add a conflict for these rules: `_type`, `abstract_type`
```

</details>

two: as a drive-by-fix in 36e527beafcf6d447064a0801f0e049217d28692, i simplified the `bounded_type` rule, and also made it more correct. previously it would not allow `impl use<'a> + 'a + Trait`, which it should syntactically according to [the](https://doc.rust-lang.org/reference/types/impl-trait.html#impl-trait) [reference](https://doc.rust-lang.org/reference/trait-bounds.html#trait-and-lifetime-bounds). i fixed this here, because (at least in my testing) it doesn't actually change anything and i thought it would be a little silly as an extra pr, but i can split it out if you want me to.

as usual, the diff for the rustc test suite (#229):

<details>
<summary>the diff</summary>

```diff
--- .tmp/list.txt	2025-02-28 16:16:12.002933806 +0100
+++ .tmp/list.txt.impl-lifetime-first	2025-03-01 00:04:53.211638735 +0100
@@ -167,8 +167,6 @@
 tests/ui/hygiene/trait_items-2.rs
 tests/ui/hygiene/traits-in-scope.rs
 tests/ui/impl-trait/equality-rpass.rs
-tests/ui/implied-bounds/dyn-erasure-no-tait.rs
-tests/ui/implied-bounds/dyn-erasure-tait.rs
 tests/ui/imports/extern-crate-used.rs
 tests/ui/imports/import-glob-crate.rs
 tests/ui/imports/local-modularized-tricky-pass-2.rs
@@ -176,7 +174,6 @@
 tests/ui/inline-const/const-match-pat-range.rs
 tests/ui/inline-const/pat-unsafe.rs
 tests/ui/issues/issue-22471.rs
-tests/ui/issues/issue-26186.rs
 tests/ui/issues/issue-36116.rs
 tests/ui/issues/issue-37051.rs
 tests/ui/issues/issue-37733.rs
@@ -315,8 +312,6 @@
 tests/ui/try-trait/yeet-for-result.rs
 tests/ui/type-alias-impl-trait/closure_parent_substs.rs
 tests/ui/type-alias-impl-trait/issue-57611-trait-alias.rs
-tests/ui/type-alias-impl-trait/issue-58662-coroutine-with-lifetime.rs
-tests/ui/type-alias-impl-trait/issue-58662-simplified.rs
 tests/ui/type/type-alias-bounds.rs
 tests/ui/type_length_limit.rs
 tests/ui/typeck/auxiliary/tdticc_coherence_lib.rs
```

</details>