### PR TITLE
fix where clauses in type aliases and allow empty where clauses

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -466,8 +466,10 @@ module.exports = grammar({
 
     where_clause: $ => prec.right(seq(
       'where',
-      sepBy1(',', $.where_predicate),
-      optional(','),
+      optional(seq(
+        sepBy1(',', $.where_predicate),
+        optional(','),
+      )),
     )),
 
     where_predicate: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -425,6 +425,7 @@ module.exports = grammar({
       'type',
       field('name', $._type_identifier),
       field('type_parameters', optional($.type_parameters)),
+      optional($.where_clause),
       '=',
       field('type', $._type),
       optional($.where_clause),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2240,6 +2240,18 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "where_clause"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "="
         },
@@ -2542,36 +2554,49 @@
             "value": "where"
           },
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "where_predicate"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "where_predicate"
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": ","
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "where_predicate"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "where_predicate"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4901,7 +4901,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "where_predicate",

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1142,6 +1142,30 @@ type LazyResolve = impl (FnOnce() -> Capture) + Send + Sync + UnwindSafe;
       (type_identifier))))
 
 ================================================================================
+Type alias where clauses
+================================================================================
+
+type Foo<T> where T: Copy = Box<T>;
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (type_item
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (where_clause
+      (where_predicate
+        (type_identifier)
+        (trait_bounds
+          (type_identifier))))
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)))))
+
+================================================================================
 Empty statements
 ================================================================================
 

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1146,6 +1146,7 @@ Type alias where clauses
 ================================================================================
 
 type Foo<T> where T: Copy = Box<T>;
+type Assoc3 where = () where;
 
 --------------------------------------------------------------------------------
 
@@ -1163,7 +1164,12 @@ type Foo<T> where T: Copy = Box<T>;
     (generic_type
       (type_identifier)
       (type_arguments
-        (type_identifier)))))
+        (type_identifier))))
+  (type_item
+    (type_identifier)
+    (where_clause)
+    (unit_type)
+    (where_clause)))
 
 ================================================================================
 Empty statements


### PR DESCRIPTION
according to the [reference](https://doc.rust-lang.org/reference/items/type-aliases.html#type-aliases), type aliases can also have a `where_clause` in front of the `=` in addition to one after it. this is fixed in 42dce44602ad6c600ee1b0d8429730aa617f70bf.

and also according to the [reference](https://doc.rust-lang.org/reference/items/generics.html#where-clauses), `where` clauses can also be empty. i didn't just change the `sepBy1` to a `sepBy`, because that would allow a trailing comma without any rules, which is not allowed. this is fixed in f2be460dd61c2cebd1fc8d0fa0b8fffffc8ca6ed.

diff for #229:

<details>
<summary>this is gonna be so diff trust me</summary>

```diff
--- .tmp/list.txt	2025-02-28 16:16:12.002933806 +0100
+++ .tmp/list.txt.type-alias-where-before-assignment.optional-where-clause	2025-03-01 01:13:03.203344726 +0100
@@ -21,7 +21,6 @@
 tests/mir-opt/coroutine_tiny.rs
 tests/mir-opt/tail_call_drops.rs
 tests/pretty/delegation.rs
-tests/pretty/issue-25031.rs
 tests/pretty/macro.rs
 tests/pretty/stmt_expr_attributes.rs
 tests/pretty/yeet-expr.rs
@@ -42,7 +41,6 @@
 tests/ui/associated-type-bounds/return-type-notation/path-constrained-in-method.rs
 tests/ui/associated-type-bounds/return-type-notation/path-self-qself.rs
 tests/ui/associated-type-bounds/return-type-notation/path-works.rs
-tests/ui/associated-type-bounds/type-alias.rs
 tests/ui/associated-types/default-associated-types.rs
 tests/ui/associated-types/issue-25339.rs
 tests/ui/associated-types/issue-32350.rs
@@ -145,7 +143,6 @@
 tests/ui/feature-gates/feature-gate-trivial_bounds-lint.rs
 tests/ui/for-loop-while/loop-break-value.rs
 tests/ui/generic-associated-types/collections.rs
-tests/ui/generic-associated-types/issue-93341.rs
 tests/ui/generic-const-items/assoc-const-AnonConst-ice-108220.rs
 tests/ui/generic-const-items/associated-const-equality.rs
 tests/ui/generic-const-items/basic.rs
@@ -175,7 +172,6 @@
 tests/ui/inline-const/const-match-pat-inference.rs
 tests/ui/inline-const/const-match-pat-range.rs
 tests/ui/inline-const/pat-unsafe.rs
-tests/ui/issues/issue-22471.rs
 tests/ui/issues/issue-26186.rs
 tests/ui/issues/issue-36116.rs
 tests/ui/issues/issue-37051.rs
@@ -313,11 +309,9 @@
 tests/ui/try-block/try-is-identifier-edition2015.rs
 tests/ui/try-trait/yeet-for-option.rs
 tests/ui/try-trait/yeet-for-result.rs
-tests/ui/type-alias-impl-trait/closure_parent_substs.rs
 tests/ui/type-alias-impl-trait/issue-57611-trait-alias.rs
 tests/ui/type-alias-impl-trait/issue-58662-coroutine-with-lifetime.rs
 tests/ui/type-alias-impl-trait/issue-58662-simplified.rs
-tests/ui/type/type-alias-bounds.rs
 tests/ui/type_length_limit.rs
 tests/ui/typeck/auxiliary/tdticc_coherence_lib.rs
 tests/ui/underscore-imports/hygiene-2.rs
@@ -325,5 +319,3 @@
 tests/ui/underscore-method-after-integer.rs
 tests/ui/unsafe-binders/expr.rs
 tests/ui/unsafe-binders/simple.rs
-tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.rs
-tests/ui/where-clauses/where-clause-placement-assoc-type-in-trait.rs
```

</detailas>