### PR TITLE
add parsing support for `use ::*` syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -653,7 +653,7 @@ module.exports = grammar({
     ),
 
     use_wildcard: $ => seq(
-      optional(seq($._path, '::')),
+      optional(seq(optional($._path), '::')),
       '*',
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3698,8 +3698,16 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_path"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_path"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
                 {
                   "type": "STRING",

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -421,6 +421,7 @@ use sayings::english::{self, greetings as en_greetings, farewells as en_farewell
 use three::{ dot::{one, four} };
 use my::{ some::* };
 use my::{*};
+use ::*;
 
 --------------------------------------------------------------------------------
 
@@ -499,7 +500,9 @@ use my::{*};
     argument: (scoped_use_list
       path: (identifier)
       list: (use_list
-        (use_wildcard)))))
+        (use_wildcard))))
+  (use_declaration
+    argument: (use_wildcard)))
 
 ================================================================================
 Variable bindings


### PR DESCRIPTION
this is modeled after [the import-glob-crate test](https://github.com/rust-lang/rust/blob/aa3c2d73eff57d6b019c26a1e9aa8afd8bc186ad/tests/ui/imports/import-glob-crate.rs). but i only found out after parsing that this test actually only works on rust 2015, for all other editions it just doesn't work.

if you don't want to support silly rust 2015 features, then i will completely understand if you don't merge this in, i just didn't realize until too late and now i have the fix so i may as well just create a pr anyway

i have patched my rustc-vs-tree-sitter-rust-mismatch finder script to only print tests that also work in rust 2018+, cause i don't really want to waste my time on rust 2015 only features.

the slightly miserable diff of rustc tests:

<details>
<summary>this is kinda silly</summary>

```diff
--- .tmp/list.txt	2025-02-28 16:16:12.002933806 +0100
+++ .tmp/list.txt.import-glob-crate	2025-03-01 04:07:23.824110326 +0100
@@ -170,7 +170,6 @@
 tests/ui/implied-bounds/dyn-erasure-no-tait.rs
 tests/ui/implied-bounds/dyn-erasure-tait.rs
 tests/ui/imports/extern-crate-used.rs
-tests/ui/imports/import-glob-crate.rs
 tests/ui/imports/local-modularized-tricky-pass-2.rs
 tests/ui/inline-const/const-match-pat-inference.rs
 tests/ui/inline-const/const-match-pat-range.rs
```

</details>