### PR TITLE
implement range-to patterns

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1454,20 +1454,29 @@ module.exports = grammar({
       $._pattern,
     )),
 
-    range_pattern: $ => seq(
-      choice(
-        $._literal_pattern,
-        $._path,
-      ),
-      choice(
-        seq(
-          choice('...', '..=', '..'),
-          choice(
-            $._literal_pattern,
-            $._path,
+    range_pattern: $ => choice(
+      seq(
+        field('left', choice(
+          $._literal_pattern,
+          $._path,
+        )),
+        choice(
+          seq(
+            choice('...', '..=', '..'),
+            field('right', choice(
+              $._literal_pattern,
+              $._path,
+            )),
           ),
+          '..',
         ),
-        '..',
+      ),
+      seq(
+        choice('..=', '..'),
+        field('right', choice(
+          $._literal_pattern,
+          $._path,
+        )),
       ),
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8626,17 +8626,21 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_literal_pattern"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_path"
-                }
-              ]
+              "type": "FIELD",
+              "name": "left",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_literal_pattern"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_path"
+                  }
+                ]
+              }
             },
             {
               "type": "CHOICE",
@@ -8662,17 +8666,21 @@
                       ]
                     },
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_literal_pattern"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "_path"
-                        }
-                      ]
+                      "type": "FIELD",
+                      "name": "right",
+                      "content": {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_literal_pattern"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_path"
+                          }
+                        ]
+                      }
                     }
                   ]
                 },
@@ -8701,17 +8709,21 @@
               ]
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_literal_pattern"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_path"
-                }
-              ]
+              "type": "FIELD",
+              "name": "right",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_literal_pattern"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_path"
+                  }
+                ]
+              }
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8620,62 +8620,98 @@
       }
     },
     "range_pattern": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_literal_pattern"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_path"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "..."
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "..="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": ".."
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_literal_pattern"
                 },
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_literal_pattern"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_path"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_path"
                 }
               ]
             },
             {
-              "type": "STRING",
-              "value": ".."
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "..."
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "..="
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ".."
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_literal_pattern"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_path"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": ".."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "..="
+                },
+                {
+                  "type": "STRING",
+                  "value": ".."
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_literal_pattern"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_path"
+                }
+              ]
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3238,40 +3238,75 @@
   {
     "type": "range_pattern",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_literal_pattern",
-          "named": true
-        },
-        {
-          "type": "crate",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "metavariable",
-          "named": true
-        },
-        {
-          "type": "scoped_identifier",
-          "named": true
-        },
-        {
-          "type": "self",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        }
-      ]
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_literal_pattern",
+            "named": true
+          },
+          {
+            "type": "crate",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "metavariable",
+            "named": true
+          },
+          {
+            "type": "scoped_identifier",
+            "named": true
+          },
+          {
+            "type": "self",
+            "named": true
+          },
+          {
+            "type": "super",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_literal_pattern",
+            "named": true
+          },
+          {
+            "type": "crate",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "metavariable",
+            "named": true
+          },
+          {
+            "type": "scoped_identifier",
+            "named": true
+          },
+          {
+            "type": "self",
+            "named": true
+          },
+          {
+            "type": "super",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -192,6 +192,8 @@ match x {
   a @ b...c => a,
   a @ b..=c => a,
   d.. => a,
+  ..d => d,
+  a @ ..=5 => a
 }
 
 match name {
@@ -226,37 +228,49 @@ match name {
             (captured_pattern
               (identifier)
               (range_pattern
-                (integer_literal)
-                (integer_literal))))
+                left: (integer_literal)
+                right: (integer_literal))))
           value: (identifier))
         (match_arm
           pattern: (match_pattern
             (tuple_struct_pattern
               type: (identifier)
               (range_pattern
-                (integer_literal)
-                (integer_literal))))
+                left: (integer_literal)
+                right: (integer_literal))))
           value: (identifier))
         (match_arm
           pattern: (match_pattern
             (captured_pattern
               (identifier)
               (range_pattern
-                (identifier)
-                (identifier))))
+                left: (identifier)
+                right: (identifier))))
           value: (identifier))
         (match_arm
           pattern: (match_pattern
             (captured_pattern
               (identifier)
               (range_pattern
-                (identifier)
-                (identifier))))
+                left: (identifier)
+                right: (identifier))))
           value: (identifier))
         (match_arm
           pattern: (match_pattern
             (range_pattern
-              (identifier)))
+              left: (identifier)))
+          value: (identifier))
+        (match_arm
+          pattern: (match_pattern
+            (range_pattern
+              right: (identifier)))
+          value: (identifier))
+        (match_arm
+          pattern: (match_pattern
+            (captured_pattern
+              (identifier)
+              (range_pattern
+                right: (integer_literal))))
           value: (identifier)))))
   (expression_statement
     (match_expression


### PR DESCRIPTION
partially specified [here](https://doc.rust-lang.org/reference/patterns.html#range-patterns) (the reference is [out of date](https://github.com/rust-lang/reference/pull/1746) and does not yet show `RangeToExclusivePattern`s).

a slightly smaller diff for #229:

<details>
<summary>diff</summary>

```diff
--- .tmp/list.txt	2025-03-01 18:19:41.855810665 +0100
+++ .tmp/list.txt.range-to-pattern	2025-03-03 00:14:52.587455370 +0100
@@ -186,7 +186,6 @@
 tests/ui/generic-const-items/const-trait-impl.rs
 tests/ui/generic-const-items/def-site-mono.rs
 tests/ui/generic-const-items/hkl_where_bounds.rs
-tests/ui/half-open-range-patterns/pat-tuple-4.rs
 tests/ui/half-open-range-patterns/range_pat_interactions0.rs
 tests/ui/higher-ranked/trait-bounds/issue-95230.rs
 tests/ui/hygiene/assoc_ty_bindings.rs
@@ -247,7 +246,6 @@
 tests/ui/parser/parser-unicode-whitespace.rs
 tests/ui/parser/trait-plusequal-splitting.rs
 tests/ui/parser/unsafe-foreign-mod.rs
-tests/ui/pattern/usefulness/integer-ranges/issue-117648-overlapping_range_endpoints-false-positive.rs
 tests/ui/privacy/decl-macro-infinite-global-import-cycle-ice-64784.rs
 tests/ui/raw-ref-op/amp-raw-without-mut-const-is-a-normal-borrow.rs
 tests/ui/resolve/non-macro-attrs-accepted.rs
```

</details>