### PR TITLE
add expr_2021 and pat_param to fragment_specifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -209,8 +209,8 @@ module.exports = grammar({
     ),
 
     fragment_specifier: _ => choice(
-      'block', 'expr', 'ident', 'item', 'lifetime', 'literal', 'meta', 'pat',
-      'path', 'stmt', 'tt', 'ty', 'vis',
+      'block', 'expr', 'expr_2021', 'ident', 'item', 'lifetime', 'literal', 'meta', 'pat',
+      'pat_param', 'path', 'stmt', 'tt', 'ty', 'vis',
     ),
 
     _tokens: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -546,6 +546,10 @@
         },
         {
           "type": "STRING",
+          "value": "expr_2021"
+        },
+        {
+          "type": "STRING",
           "value": "ident"
         },
         {
@@ -567,6 +571,10 @@
         {
           "type": "STRING",
           "value": "pat"
+        },
+        {
+          "type": "STRING",
+          "value": "pat_param"
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5308,6 +5308,10 @@
     "named": false
   },
   {
+    "type": "expr_2021",
+    "named": false
+  },
+  {
     "type": "extern",
     "named": false
   },
@@ -5409,6 +5413,10 @@
   },
   {
     "type": "pat",
+    "named": false
+  },
+  {
+    "type": "pat_param",
     "named": false
   },
   {


### PR DESCRIPTION
adds `expr_2021` and `pat_param` to [possible fragment specifiers](https://doc.rust-lang.org/reference/macros-by-example.html#metavariables). added for backwards compatability for the release of [the 2024 edition](https://github.com/rust-lang/rust/issues/123742) and [the 2021 edition](https://github.com/rust-lang/rust/pull/83386/) respectively.

diff for #229:

<details>
<summary>diff</summary>

```diff
--- .tmp/list.txt	2025-03-07 03:57:30.021995759 +0100
+++ .tmp/list.txt.expr-2021	2025-03-07 03:00:11.631475182 +0100
@@ -211,8 +211,6 @@
 tests/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.rs
 tests/ui/lint/unused/trait-alias-supertrait.rs
 tests/ui/liveness/liveness-upvars.rs
-tests/ui/macros/edition-macro-pats.rs
-tests/ui/macros/expr_2021.rs
 tests/ui/macros/issue-44127.rs
 tests/ui/macros/issue-63102.rs
 tests/ui/macros/issue-77475.rs
```

</details>