### PR TITLE
fix nested block comments with a slash in between

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -214,6 +214,9 @@ typedef struct {
 static inline void process_left_forward_slash(BlockCommentProcessing *processing, char current) {
     if (current == '*') {
         processing->nestingDepth += 1;
+    } else if (current == '/') {
+        processing->state = LeftForwardSlash;
+        return;
     }
     processing->state = Continuing;
 };

--- a/test/corpus/source_files.txt
+++ b/test/corpus/source_files.txt
@@ -48,9 +48,18 @@ Nested block comments
 
 // ---
 
+/*
+  nested with extra slash between two nested block comments
+  /**///**/
+*/
+
+// ---
+
 ----
 
 (source_file
+  (block_comment)
+  (line_comment)
   (block_comment)
   (line_comment)
   (block_comment)


### PR DESCRIPTION
This PR fixes a bug where having a forward slash between two nested block comments throws an error.
I haven't committed a run to `tree-sitter generate` as I'm not sure if I should do so for a scanner change or not.

Bug preview (using Zed 0.188.5):
![image](https://github.com/user-attachments/assets/6c407b5d-18fb-45ef-85b1-df73a0ca8dae)

How it looks like in VSCode:
![image](https://github.com/user-attachments/assets/c5ec4293-799e-474a-b508-9ecb99f7489e)

Also added a test to `source-files.txt` test for demonstration. 

It's my first time contributing to `tree-sitter` so any feedback is appreciated.