### PR TITLE
feat: Support for `auto trait`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -238,7 +238,7 @@ module.exports = grammar({
       alias(choice(...primitiveTypes), $.primitive_type),
       prec.right(repeat1(choice(...TOKEN_TREE_NON_SPECIAL_PUNCTUATION))),
       '\'',
-      'as', 'async', 'await', 'break', 'const', 'continue', 'default', 'enum', 'fn', 'for', 'gen',
+      'as', 'async', 'auto', 'await', 'break', 'const', 'continue', 'default', 'enum', 'fn', 'for', 'gen',
       'if', 'impl', 'let', 'loop', 'match', 'mod', 'pub', 'return', 'static', 'struct', 'trait',
       'type', 'union', 'unsafe', 'use', 'where', 'while',
     ),
@@ -509,6 +509,7 @@ module.exports = grammar({
     trait_item: $ => seq(
       optional($.visibility_modifier),
       optional('unsafe'),
+      optional('auto'),
       'trait',
       field('name', $._type_identifier),
       field('type_parameters', optional($.type_parameters)),

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1706,7 +1706,7 @@ unsafe impl Trait for dyn (::std::any::Any) + Send { }
               (scoped_identifier
                 (identifier))
               (identifier))
-          (type_identifier))))
+            (type_identifier))))
       (type_identifier))
     (declaration_list)))
 
@@ -1786,6 +1786,8 @@ pub trait Item: Clone + Eq + fmt::Debug {
 
 unsafe trait Foo { }
 
+unsafe auto trait Bar { }
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1807,6 +1809,9 @@ unsafe trait Foo { }
         (scoped_type_identifier
           (identifier)
           (type_identifier)))))
+  (trait_item
+    (type_identifier)
+    (declaration_list))
   (trait_item
     (type_identifier)
     (declaration_list)))


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/13231
Stable rustc is already able to parse those (with the appropriate feature gate).

Closes #267.

Note: this change is taken from my fork [tree-sitter-rust-orchard](https://codeberg.org/grammar-orchard/tree-sitter-rust-orchard). I thought I would open PRs for easily portable changes like this one, even if there is no prospect of them being merged soon given the current maintenance status of this repository (as a way of making that status clearer). If that is too noisy, let me know and I'll stop.