### PR TITLE
feat: trait bound modifiers: `~const`, `async` and `!`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -529,7 +529,12 @@ module.exports = grammar({
     trait_bounds: $ => seq(
       ':',
       sepBy1('+', choice(
-        $._type,
+        prec(1, seq(
+          optional("~const"),
+          optional("async"),
+          optional("!"),
+          $._type
+        )),
         $.lifetime,
         $.higher_ranked_trait_bound,
       )),

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1910,6 +1910,35 @@ impl<T: AstDeref<Target: HasNodeId>> HasNodeId for T {}
     (declaration_list)))
 
 ================================================================================
+Trait bounds with modifiers
+================================================================================
+
+impl <T: !Y> Foo for Bar {}
+impl <T: ~const async Y> Foo for Bar {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (impl_item
+    (type_parameters
+      (type_parameter
+        (type_identifier)
+        (trait_bounds
+          (type_identifier))))
+    (type_identifier)
+    (type_identifier)
+    (declaration_list))
+  (impl_item
+    (type_parameters
+      (type_parameter
+        (type_identifier)
+        (trait_bounds
+          (type_identifier))))
+    (type_identifier)
+    (type_identifier)
+    (declaration_list)))
+
+================================================================================
 Macro invocations inside trait declarations
 ================================================================================
 


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/67792. This syntax is already supported by rustc stable, 2024 edition, with the appropriate feature gate.

Note: this change is taken from my fork [tree-sitter-rust-orchard](https://codeberg.org/grammar-orchard/tree-sitter-rust-orchard). I thought I would open PRs for easily portable changes like this one, even if there is no prospect of them being merged soon given the current maintenance status of this repository (as a way of making that status clearer). If that is too noisy, let me know and I'll stop.