### PR TITLE
allow method calls on integers to start with a `_`

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -205896,7 +205896,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_rust(void) {
     .metadata = {
       .major_version = 0,
       .minor_version = 24,
-      .patch_version = 1,
+      .patch_version = 2,
     },
   };
   return &language;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -133,8 +133,8 @@ static inline bool process_float_literal(TSLexer *lexer) {
     if (lexer->lookahead == '.') {
         has_fraction = true;
         advance(lexer);
-        if (iswalpha(lexer->lookahead)) {
-            // The dot is followed by a letter: 1.max(2) => not a float but an integer
+        if (iswalpha(lexer->lookahead) || lexer->lookahead == '_') {
+            // The dot is followed by a letter or _: 1.max(2) => not a float but an integer
             return false;
         }
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -994,6 +994,7 @@ mystruct.myfield;
 foo().x;
 value.0.1.iter();
 1.max(2);
+1._method();
 
 --------------------------------------------------------------------------------
 
@@ -1024,7 +1025,13 @@ value.0.1.iter();
         (integer_literal)
         (field_identifier))
       (arguments
-        (integer_literal)))))
+        (integer_literal))))
+  (expression_statement
+    (call_expression
+      (field_expression
+        (integer_literal)
+        (field_identifier))
+      (arguments))))
 
 ================================================================================
 Method call expressions


### PR DESCRIPTION
this basically allows for `42._method()` to properly parse as the call of the method `_method` on the integer `42`.

the [FLOAT_LITERAL reference](https://doc.rust-lang.org/reference/tokens.html#grammar-FLOAT_LITERAL) explicitly states `not immediately followed by ., _ or an XID_Start character` for the character after an ending dot, so disallow this here too.

this fixes exactly one rustc test: [integer-literal-method-call-underscore.rs](https://github.com/rust-lang/rust/blob/34f954f9b7cbdb5e9b408bac1c4ff1e88b5f2719/tests/ui/parser/integer-literal-method-call-underscore.rs), the test that was for exactly this behaviour.

(noticed this while working on #293)