### PR TITLE
allow building free-threaded wheels on 3.14t

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from os.path import isdir, join
 from platform import system
+from sysconfig import get_config_var
 
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build import build
 from wheel.bdist_wheel import bdist_wheel
+
+# The limited API is not supported on free-threaded builds
+LIMITED_API = not get_config_var("Py_GIL_DISABLED")
 
 
 class Build(build):
@@ -17,7 +21,7 @@ class Build(build):
 class BdistWheel(bdist_wheel):
     def get_tag(self):
         python, abi, platform = super().get_tag()
-        if python.startswith("cp"):
+        if python.startswith("cp") and LIMITED_API:
             python, abi = "cp39", "abi3"
         return python, abi, platform
 
@@ -46,12 +50,13 @@ setup(
                 "/utf-8",
             ],
             define_macros=[
-                ("Py_LIMITED_API", "0x03090000"),
                 ("PY_SSIZE_T_CLEAN", None),
                 ("TREE_SITTER_HIDE_SYMBOLS", None),
-            ],
+            ] + (
+                [("Py_LIMITED_API", "0x03090000")] if LIMITED_API else []
+            ),
             include_dirs=["src"],
-            py_limited_api=True,
+            py_limited_api=LIMITED_API,
         )
     ],
     cmdclass={


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter-rust/issues/302

This PR allows building free-threaded wheels for `tree-sitter-rust` which cannot use existing abi3 wheels.